### PR TITLE
add conversion from stdx to SPIRV

### DIFF
--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -11,7 +11,6 @@ CppEdsl.HigherPrecisionConstants
 CppEdsl.MnistCnn
 CppEdsl.Prng
 CppEdsl.Pow
-CppEdsl.SinH
 CppEdsl.Winograd
 
 

--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -7,7 +7,6 @@ CppEdsl.ComplexConv2d
 CppEdsl.ConvI8
 CppEdsl.CosH
 CppEdsl.Erf
-CppEdsl.Floor
 CppEdsl.HigherPrecisionInvalidNegative
 CppEdsl.HigherPrecisionConstants
 CppEdsl.MnistCnn

--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -13,7 +13,6 @@ CppEdsl.HigherPrecisionConstants
 CppEdsl.MnistCnn
 CppEdsl.Prng
 CppEdsl.Pow
-CppEdsl.Round
 CppEdsl.SinH
 CppEdsl.Tan
 CppEdsl.Winograd

--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -13,7 +13,6 @@ CppEdsl.MnistCnn
 CppEdsl.Prng
 CppEdsl.Pow
 CppEdsl.SinH
-CppEdsl.Tan
 CppEdsl.Winograd
 
 

--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -5,7 +5,6 @@ CppEdsl.BitNot
 CppEdsl.BitRightScalar
 CppEdsl.ComplexConv2d
 CppEdsl.ConvI8
-CppEdsl.CosH
 CppEdsl.Erf
 CppEdsl.HigherPrecisionInvalidNegative
 CppEdsl.HigherPrecisionConstants

--- a/pmlc/conversion/gpu_to_spirv/gpu_to_spirv.cc
+++ b/pmlc/conversion/gpu_to_spirv/gpu_to_spirv.cc
@@ -82,6 +82,20 @@ struct StdxFloorOpConversion : public SPIRVOpLowering<stdx::FloorOp> {
   }
 };
 
+struct StdxTanOpConversion : public SPIRVOpLowering<stdx::TanOp> {
+  using SPIRVOpLowering<stdx::TanOp>::SPIRVOpLowering;
+
+  LogicalResult
+  matchAndRewrite(stdx::TanOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const final {
+    assert(operands.size() == 1);
+    auto dstType = op.getResult().getType();
+    rewriter.replaceOpWithNewOp<spirv::GLSLTanOp>(op, dstType,
+                                                  operands.front());
+    return success();
+  }
+};
+
 struct GPUToSPIRVCustomPass
     : public GPUToSPIRVCustomBase<GPUToSPIRVCustomPass> {
   void runOnOperation() final {
@@ -120,7 +134,8 @@ void populateStdxToSPIRVPatterns(MLIRContext *context,
                                  SPIRVTypeConverter &typeConverter,
                                  OwningRewritePatternList &patterns) {
   patterns.insert<StdxSubgroupBroadcastOpConversion, StdxRoundOpConversion,
-                  StdxFloorOpConversion>(context, typeConverter);
+                  StdxFloorOpConversion, StdxTanOpConversion>(context,
+                                                              typeConverter);
 }
 
 std::unique_ptr<Pass> createGPUToSPIRVCustomPass() {

--- a/pmlc/conversion/gpu_to_spirv/gpu_to_spirv.cc
+++ b/pmlc/conversion/gpu_to_spirv/gpu_to_spirv.cc
@@ -68,6 +68,20 @@ struct StdxRoundOpConversion : public SPIRVOpLowering<stdx::RoundOp> {
   }
 };
 
+struct StdxFloorOpConversion : public SPIRVOpLowering<stdx::FloorOp> {
+  using SPIRVOpLowering<stdx::FloorOp>::SPIRVOpLowering;
+
+  LogicalResult
+  matchAndRewrite(stdx::FloorOp op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const final {
+    assert(operands.size() == 1);
+    auto dstType = op.getResult().getType();
+    rewriter.replaceOpWithNewOp<spirv::GLSLFloorOp>(op, dstType,
+                                                    operands.front());
+    return success();
+  }
+};
+
 struct GPUToSPIRVCustomPass
     : public GPUToSPIRVCustomBase<GPUToSPIRVCustomPass> {
   void runOnOperation() final {
@@ -105,8 +119,8 @@ struct GPUToSPIRVCustomPass
 void populateStdxToSPIRVPatterns(MLIRContext *context,
                                  SPIRVTypeConverter &typeConverter,
                                  OwningRewritePatternList &patterns) {
-  patterns.insert<StdxSubgroupBroadcastOpConversion, StdxRoundOpConversion>(
-      context, typeConverter);
+  patterns.insert<StdxSubgroupBroadcastOpConversion, StdxRoundOpConversion,
+                  StdxFloorOpConversion>(context, typeConverter);
 }
 
 std::unique_ptr<Pass> createGPUToSPIRVCustomPass() {

--- a/pmlc/conversion/gpu_to_spirv/passes.h
+++ b/pmlc/conversion/gpu_to_spirv/passes.h
@@ -17,6 +17,10 @@ void populateStdxToSPIRVPatterns(mlir::MLIRContext *context,
                                  mlir::SPIRVTypeConverter &typeConverter,
                                  mlir::OwningRewritePatternList &patterns);
 
+void populateStdxToSPIRVGLSLPatterns(mlir::MLIRContext *context,
+                                     mlir::SPIRVTypeConverter &typeConverter,
+                                     mlir::OwningRewritePatternList &patterns);
+
 std::unique_ptr<mlir::Pass> createGPUToSPIRVCustomPass();
 
 /// Generate the code for registering conversion passes.

--- a/pmlc/conversion/gpu_to_spirv/tests/stdx_to_spv.mlir
+++ b/pmlc/conversion/gpu_to_spirv/tests/stdx_to_spv.mlir
@@ -1,0 +1,67 @@
+// RUN: pmlc-opt -gpu-to-spirv-custom %s | FileCheck %s
+
+module attributes {gpu.container_module, spv.target_env = #spv.target_env<#spv.vce<v1.0, [Shader, Groups, Int64, Int16, Int8, Float64, Float16], [SPV_KHR_storage_buffer_storage_class]>, {max_compute_workgroup_invocations = 128 : i32, max_compute_workgroup_size = dense<[128, 128, 64]> : vector<3xi32>}>} {
+  func @cosh(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+    %c1 = constant 1 : index
+    %c3 = constant 3 : index
+    "gpu.launch_func"(%c1, %c1, %c1, %c3, %c3, %c1, %arg0, %arg1) {kernel = @cosh_kernel::@cosh_kernel} : (index, index, index, index, index, index, memref<3x3xf32>, memref<3x3xf32>) -> ()
+    "gpu.launch_func"(%c1, %c1, %c1, %c3, %c3, %c1, %arg0, %arg1) {kernel = @sinh_kernel::@sinh_kernel} : (index, index, index, index, index, index, memref<3x3xf32>, memref<3x3xf32>) -> ()
+    "gpu.launch_func"(%c1, %c1, %c1, %c3, %c3, %c1, %arg0, %arg1) {kernel = @floor_kernel::@floor_kernel} : (index, index, index, index, index, index, memref<3x3xf32>, memref<3x3xf32>) -> ()
+    "gpu.launch_func"(%c1, %c1, %c1, %c3, %c3, %c1, %arg0, %arg1) {kernel = @tan_kernel::@tan_kernel} : (index, index, index, index, index, index, memref<3x3xf32>, memref<3x3xf32>) -> ()
+    return
+  }
+  gpu.module @cosh_kernel {
+    gpu.func @cosh_kernel(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[3, 3, 1]> : vector<3xi32>}} {
+      %0 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "y"} : () -> index
+      %2 = load %arg0[%0, %1] : memref<3x3xf32>
+      // CHECK: spv.GLSL.Exp
+      // CHECK-NEXT: spv.FNegate
+      // CHECK-NEXT: spv.GLSL.Exp
+      // CHECK-NEXT: spv.FSub
+      // CHECK-NEXT: spv.constant
+      // CHECK-NEXT: spv.FDiv
+      %3 = stdx.cosh(%2) : (f32) -> f32
+      store %3, %arg1[%0, %1] : memref<3x3xf32>
+      gpu.return
+    }
+  }
+  gpu.module @sinh_kernel {
+    gpu.func @sinh_kernel(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[3, 3, 1]> : vector<3xi32>}} {
+      %0 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "y"} : () -> index
+      %2 = load %arg0[%0, %1] : memref<3x3xf32>
+      // CHECK: spv.GLSL.Exp
+      // CHECK-NEXT: spv.FNegate
+      // CHECK-NEXT: spv.GLSL.Exp
+      // CHECK-NEXT: spv.FSub
+      // CHECK-NEXT: spv.constant
+      // CHECK-NEXT: spv.FDiv
+      %3 = stdx.sinh(%2) : (f32) -> f32
+      store %3, %arg1[%0, %1] : memref<3x3xf32>
+      gpu.return
+    }
+  }
+  gpu.module @floor_kernel {
+    gpu.func @floor_kernel(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[3, 3, 1]> : vector<3xi32>}} {
+      %0 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "y"} : () -> index
+      %2 = load %arg0[%0, %1] : memref<3x3xf32>
+      // CHECK: spv.GLSL.Floor
+      %3 = stdx.floor(%2) : (f32) -> f32
+      store %3, %arg1[%0, %1] : memref<3x3xf32>
+      gpu.return
+    }
+  }
+  gpu.module @tan_kernel {
+    gpu.func @tan_kernel(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) kernel attributes {spv.entry_point_abi = {local_size = dense<[3, 3, 1]> : vector<3xi32>}} {
+      %0 = "gpu.thread_id"() {dimension = "x"} : () -> index
+      %1 = "gpu.thread_id"() {dimension = "y"} : () -> index
+      %2 = load %arg0[%0, %1] : memref<3x3xf32>
+      // CHECK: spv.GLSL.Tan
+      %3 = stdx.tan(%2) : (f32) -> f32
+      store %3, %arg1[%0, %1] : memref<3x3xf32>
+      gpu.return
+    }
+  }
+}


### PR DESCRIPTION
Draft stdx_to_spirv pass. Know issues includes:
~~1. SPIRV doesn't support i1 so when stdx.uitofp uses i1 operand the conversion will fail.~~
~~2. Seems SPIRV has Ceil and Floor ops but not Round. The problems comes up when stdx.round is operating a tensor instead of a single operand. Because we cannot use Ceil and Floor at the same time eltwisely thus the result might be wrong.~~
TBD...