### PR TITLE
draft add summation/update feature and axis parameter to scatter op

### DIFF
--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -905,7 +905,28 @@ inline Tensor round(const Tensor& x) { return intrinsic("round", x); }
 /// \param z Tensor
 /// \return Tensor
 ///
-inline Tensor scatter(const Tensor& x, const Tensor& y, const Tensor& z) { return intrinsic("scatter", x, y, z); }
+class scatter {
+public:
+  explicit scatter(const Tensor& x, const Tensor& y, const Tensor& z) : x_(x), y_(y), z_(z) {}
+
+  scatter& axis(int axis) {
+    axis_ = Tensor(axis);
+    return *this;
+  }
+
+  Tensor build() const {
+    std::vector<Tensor> args = {x_, y_, z_, axis_};
+    return intrinsicCall("scatter", args);
+  }
+
+  operator Tensor() { return build(); }
+
+private:
+  Tensor x_;
+  Tensor y_;
+  Tensor z_;
+  Tensor axis_ = Tensor(0);
+};
 
 ///
 /// Performs an elementwise conditional which returns the corresponding

--- a/plaidml/edsl/edsl.h
+++ b/plaidml/edsl/edsl.h
@@ -897,6 +897,12 @@ inline Tensor reshape(const Tensor& x, const std::vector<TensorDim>& dims) {
 ///
 inline Tensor round(const Tensor& x) { return intrinsic("round", x); }
 
+enum class ScatterUpdateMode : uint64_t {
+  SUM,
+  SLICE,
+  ELET
+};
+
 ///
 /// Takes an input tensor (`x`), a set of indices to scatter over (`y`), and the number of elements in the scattered
 /// tensor (`z`), and returns an output tensor that scatters the input tensor across the number of elements specified.
@@ -914,8 +920,13 @@ public:
     return *this;
   }
 
+  scatter& update(ScatterUpdateMode mode) {
+    update_mode_ = Tensor(static_cast<uint64_t>(mode));
+    return *this;
+  }
+
   Tensor build() const {
-    std::vector<Tensor> args = {x_, y_, z_, axis_};
+    std::vector<Tensor> args = {x_, y_, z_, axis_, update_mode_};
     return intrinsicCall("scatter", args);
   }
 
@@ -926,6 +937,7 @@ private:
   Tensor y_;
   Tensor z_;
   Tensor axis_ = Tensor(0);
+  Tensor update_mode_ = Tensor(static_cast<uint64_t>(ScatterUpdateMode::SUM));
 };
 
 ///

--- a/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
+++ b/plaidml/edsl/tests/edsl_test-skip.intel_gen.txt
@@ -7,5 +7,3 @@ CppEdsl.ConvI8
 CppEdsl.DotF16_AccF32
 CppEdsl.Erf
 CppEdsl.HigherPrecisionConstants
-CppEdsl.Scatter1D
-CppEdsl.Scatter3D

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1448,41 +1448,65 @@ TEST_F(CppEdsl, Tan) {
 }
 
 TEST_F(CppEdsl, Scatter1D) {
+  auto D = Placeholder(DType::FLOAT32, {8});
   auto I = Placeholder(DType::INT32, {4});
   auto U = Placeholder(DType::FLOAT32, {4});
-  auto S = Placeholder(DType::INT32, {8});
-  auto O = scatter(U, I, S);
-  auto program = makeProgram("scatter", {I, U, S}, {O});
+  auto O = scatter(D, I, U).axis(0);
+  auto program = makeProgram("scatter", {D, I, U}, {O});
 
   std::vector<int32_t> indices = {4, 3, 1, 7};
   std::vector<float> updates = {9, 10, 11, 12};
-  std::vector<int32_t> shape = {8};
+  std::vector<int32_t> data = {8};
   std::vector<float> expected = {0, 11, 0, 10, 9, 0, 0, 12};
-  checkExact(program, {indices, updates, shape}, {expected});
+  checkExact(program, {data, indices, updates}, {expected});
+}
+
+TEST_F(CppEdsl, Scatter2D) {
+  auto D = Placeholder(DType::FLOAT32, {4, 8});
+  auto I = Placeholder(DType::INT32, {4});
+  auto U = Placeholder(DType::FLOAT32, {4, 4});
+  auto O = scatter(D, I, U).axis(1);
+  auto program = makeProgram("scatter", {D, I, U}, {O});
+
+  std::vector<int32_t> indices = {0, 2, 4, 6};
+  std::vector<float> updates = {
+      4, 4, 4, 4,
+      5, 5, 5, 5,
+      6, 6, 6, 6,
+      7, 7, 7, 7
+  };
+  std::vector<int32_t> data = {4, 8};
+  std::vector<float> expected = {
+      4, 0, 4, 0, 4, 0, 4, 0,
+      5, 0, 5, 0, 5, 0, 5, 0,
+      6, 0, 6, 0, 6, 0, 6, 0,
+      7, 0, 7, 0, 7, 0, 7, 0
+  };
+  checkExact(program, {data, indices, updates}, {expected});
 }
 
 TEST_F(CppEdsl, Scatter3D) {
-  auto I = Placeholder(DType::INT32, {2});
+  auto D = Placeholder(DType::FLOAT32, {2, 8, 4});
+  auto I = Placeholder(DType::INT32, {4});
   auto U = Placeholder(DType::FLOAT32, {2, 4, 4});
-  auto S = Placeholder(DType::INT32, {4, 4, 4});
-  auto O = scatter(U, I, S);
-  auto program = makeProgram("scatter", {I, U, S}, {O});
+  auto O = scatter(D, I, U).axis(1);
+  auto program = makeProgram("scatter", {D, I, U}, {O});
 
-  std::vector<int32_t> indices = {0, 2};
+  std::vector<int32_t> indices = {0, 1, 2, 3};
   std::vector<float> updates = {
       5, 5, 5, 5, 6, 6, 6, 6,  //
       7, 7, 7, 7, 8, 8, 8, 8,  //
       5, 5, 5, 5, 6, 6, 6, 6,  //
       7, 7, 7, 7, 8, 8, 8, 8   //
   };
-  std::vector<int32_t> shape = {4, 4, 4};
+  std::vector<int32_t> data = {2, 8, 4};
   std::vector<float> expected = {
       5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8,  //
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  //
       5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8,  //
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0   //
   };
-  checkExact(program, {indices, updates, shape}, {expected});
+  checkExact(program, {data, indices, updates}, {expected});
 }
 
 TEST_F(CppEdsl, Trace) {

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1490,6 +1490,36 @@ TEST_F(CppEdsl, Scatter2D) {
   checkExact(program, {data, indices, updates}, {expected});
 }
 
+TEST_F(CppEdsl, ScatterElet) {
+  auto D = Placeholder(DType::FLOAT32, {4, 4});
+  auto I = Placeholder(DType::INT32, {2, 2});
+  auto U = Placeholder(DType::FLOAT32, {2, 2});
+  auto O = scatter(D, I, U).axis(1).update(ScatterUpdateMode::ELET);
+  auto program = makeProgram("scatter", {D, I, U}, {O});
+
+  std::vector<int32_t> indices = {
+      2, 0,
+      3, 1
+  };
+  std::vector<float> updates = {
+      9, 9,
+      9, 9
+  };
+  std::vector<float> data = {
+      4, 1, 4, 5,
+      4, 2, 4, 4,
+      4, 3, 4, 0,
+      4, 4, 4, 3,
+  };
+  std::vector<float> expected = {
+      9, 1, 9, 5,
+      4, 9, 4, 9,
+      4, 3, 4, 0,
+      4, 4, 4, 3,
+  };
+  checkExact(program, {data, indices, updates}, {expected});
+}
+
 TEST_F(CppEdsl, Scatter3D) {
   auto D = Placeholder(DType::FLOAT32, {2, 8, 4});
   auto I = Placeholder(DType::INT32, {4});

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1451,7 +1451,7 @@ TEST_F(CppEdsl, Scatter1D) {
   auto D = Placeholder(DType::FLOAT32, {8});
   auto I = Placeholder(DType::INT32, {4});
   auto U = Placeholder(DType::FLOAT32, {4});
-  auto O = scatter(D, I, U).axis(0);
+  auto O = scatter(D, I, U).axis(0).update(ScatterUpdateMode::SUM);
   auto program = makeProgram("scatter", {D, I, U}, {O});
 
   std::vector<int32_t> indices = {4, 3, 1, 7};
@@ -1465,7 +1465,7 @@ TEST_F(CppEdsl, Scatter2D) {
   auto D = Placeholder(DType::FLOAT32, {4, 8});
   auto I = Placeholder(DType::INT32, {4});
   auto U = Placeholder(DType::FLOAT32, {4, 4});
-  auto O = scatter(D, I, U).axis(1);
+  auto O = scatter(D, I, U).axis(1).update(ScatterUpdateMode::SLICE);
   auto program = makeProgram("scatter", {D, I, U}, {O});
 
   std::vector<int32_t> indices = {0, 2, 4, 6};
@@ -1475,12 +1475,17 @@ TEST_F(CppEdsl, Scatter2D) {
       6, 6, 6, 6,
       7, 7, 7, 7
   };
-  std::vector<int32_t> data = {4, 8};
+  std::vector<float> data = {
+      4, 1, 4, 5, 4, 9, 4, 0,
+      4, 2, 4, 4, 4, 0, 4, 7,
+      4, 3, 4, 0, 4, 8, 4, 0,
+      4, 4, 4, 3, 4, 0, 4, 0,
+  };
   std::vector<float> expected = {
-      4, 0, 4, 0, 4, 0, 4, 0,
-      5, 0, 5, 0, 5, 0, 5, 0,
-      6, 0, 6, 0, 6, 0, 6, 0,
-      7, 0, 7, 0, 7, 0, 7, 0
+      4, 1, 4, 5, 4, 9, 4, 0,
+      5, 2, 5, 4, 5, 0, 5, 7,
+      6, 3, 6, 0, 6, 8, 6, 0,
+      7, 4, 7, 3, 7, 0, 7, 0
   };
   checkExact(program, {data, indices, updates}, {expected});
 }

--- a/pmlc/ast/ast_ops.cc
+++ b/pmlc/ast/ast_ops.cc
@@ -122,8 +122,8 @@ struct ReshapeOp : Intrinsic {
 struct ScatterOp : Intrinsic {
   TensorShapes getShapes(Evaluator *evaluator, ArrayRef<ExprNodePtr> operands,
                          ArrayRef<TensorShape> shapes) const final {
-    if (operands.size() != 4) {
-      throw std::runtime_error("'scatter' requires 4 operands.");
+    if (operands.size() != 5) {
+      throw std::runtime_error("'scatter' requires 5 operands.");
     }
     // data tensor
     int64_t rank = shapes[0].getRank();
@@ -144,6 +144,13 @@ struct ScatterOp : Intrinsic {
       throw std::runtime_error(
           "'gather' primitive expects the 'axis' argument "
 	  "to be a positive integer that is less than the updates tensor rank.");
+    }
+
+    auto updateMode = getIntegerValue(evaluator, operands[4]);
+    if (!updateMode) {
+      throw std::runtime_error(
+          "'gather' primitive expects the 'updateMode' argument "
+	  "to be a constant integer.");
     }
 
     TensorShape ret(shapes[0].elementType, shapes[0].sizes);

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -747,9 +747,16 @@ struct ProgramBuilder {
 
   Value makeScatterOp(ExprNodeIntrinsic *node, ArrayRef<Value> operands) {
     TensorShape shape = evaluator.getShape(node);
+    IntegerAttr axis;
+
+    if (!matchPattern(operands[3], m_Constant(&axis))) {
+      throw std::runtime_error("'scatter' primitive expects the 'axis' argument "
+			       "to be a constant integer");
+    }
     RankedTensorType resultType = builder.getRankedTensorType(shape);
     auto op = builder.create<tile::ScatterOp>(loc, resultType,
-                                              operands.take_front(2));
+                                              operands.take_front(3),
+					      builder.getIndexAttr(axis.getInt()));
     return op.result();
   }
 

--- a/pmlc/ast/builder.cc
+++ b/pmlc/ast/builder.cc
@@ -748,15 +748,20 @@ struct ProgramBuilder {
   Value makeScatterOp(ExprNodeIntrinsic *node, ArrayRef<Value> operands) {
     TensorShape shape = evaluator.getShape(node);
     IntegerAttr axis;
+    IntegerAttr updateMode;
 
     if (!matchPattern(operands[3], m_Constant(&axis))) {
       throw std::runtime_error("'scatter' primitive expects the 'axis' argument "
 			       "to be a constant integer");
     }
+    if (!matchPattern(operands[4], m_Constant(&updateMode))) {
+      throw std::runtime_error("'scatter' primitive expects the 'updateMode' argument "
+			       "to be a constant integer");
+    }
     RankedTensorType resultType = builder.getRankedTensorType(shape);
     auto op = builder.create<tile::ScatterOp>(loc, resultType,
                                               operands.take_front(3),
-					      builder.getIndexAttr(axis.getInt()));
+					      builder.getIndexAttr(axis.getInt()), updateMode);
     return op.result();
   }
 

--- a/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
+++ b/pmlc/conversion/tile_to_pxa/tile_to_pxa.cc
@@ -1109,8 +1109,10 @@ struct ScatterOpConversion : public OpConversionPattern<tile::ScatterOp> {
       dstOps.push_back(loop.getIVs()[i]);
     }
 
+    auto loadVal = rewriter.create<mlir::LoadOp>(loc, resultMemRef, dstOps);
+    auto sumVal = rewriter.create<mlir::AddFOp>(loc, srcVal, loadVal);
     // Write the value to the destination
-    rewriter.create<mlir::StoreOp>(loc, srcVal, resultMemRef, dstOps);
+    rewriter.create<mlir::StoreOp>(loc, sumVal, resultMemRef, dstOps);
 
     rewriter.create<AffineYieldOp>(loc, ArrayRef<Value>{resultMemRef});
     rewriter.replaceOp(op, loop.getResult(0));

--- a/pmlc/dialect/tile/ir/ops.cc
+++ b/pmlc/dialect/tile/ir/ops.cc
@@ -387,10 +387,12 @@ LogicalResult verifyContractionOp(ContractionOp op) {
 }
 
 void ScatterOp::build(OpBuilder &builder, OperationState &result,
-		      Type resultType, ValueRange operands, IntegerAttr axis) {
+		      Type resultType, ValueRange operands, IntegerAttr axis,
+		      IntegerAttr updateMode) {
   assert(operands.size() == 3u && "mismatched number of parameters");
   result.addOperands(operands);
   result.addAttribute("axis", axis);
+  result.addAttribute("updateMode", updateMode);
   result.addTypes(resultType);
 }
 

--- a/pmlc/dialect/tile/ir/ops.cc
+++ b/pmlc/dialect/tile/ir/ops.cc
@@ -386,6 +386,14 @@ LogicalResult verifyContractionOp(ContractionOp op) {
   return success();
 }
 
+void ScatterOp::build(OpBuilder &builder, OperationState &result,
+		      Type resultType, ValueRange operands, IntegerAttr axis) {
+  assert(operands.size() == 3u && "mismatched number of parameters");
+  result.addOperands(operands);
+  result.addAttribute("axis", axis);
+  result.addTypes(resultType);
+}
+
 } // namespace pmlc::dialect::tile
 
 #define GET_OP_CLASSES

--- a/pmlc/dialect/tile/ir/ops.h
+++ b/pmlc/dialect/tile/ir/ops.h
@@ -23,6 +23,7 @@ using mlir::IntegerSet;
 using mlir::IntegerSetAttr;
 using util::AggregationKind;
 using util::CombinationKind;
+using util::ScatterUpdateMode;
 
 } // namespace pmlc::dialect::tile
 

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -169,14 +169,17 @@ def ScatterOp : MaterializeOp<"scatter"> {
     RankedTensorOf<[AnyScalar]>:$data,
     RankedTensorOf<[AnyScalar]>:$indices,
     RankedTensorOf<[AnyScalar]>:$updates,
-    DefaultValuedAttr<IndexAttr, "0">:$axis);
+    DefaultValuedAttr<IndexAttr, "0">:$axis,
+    DefaultValuedAttr<ScatterUpdateMode, "ScatterUpdateMode::sum">:$updateMode
+  );
   let results = (outs RankedTensorOf<[AnyScalar]>:$result);
   let builders = [OpBuilder<
     "mlir::OpBuilder &builder, "
     "mlir::OperationState& result, "
     "mlir::Type resultType, "
     "mlir::ValueRange operands, "
-    "mlir::IntegerAttr axis"
+    "mlir::IntegerAttr axis, "
+    "mlir::IntegerAttr updateMode"
   >];
 
   let assemblyFormat = [{

--- a/pmlc/dialect/tile/ir/ops.td
+++ b/pmlc/dialect/tile/ir/ops.td
@@ -166,11 +166,21 @@ def ReshapeOp : MaterializeOp<"reshape">,
 def ScatterOp : MaterializeOp<"scatter"> {
   let summary = "special scatter operation";
   let arguments = (ins
-    RankedTensorOf<[AnyScalar]>:$tensor,
-    RankedTensorOf<[AnyInteger]>:$dims);
+    RankedTensorOf<[AnyScalar]>:$data,
+    RankedTensorOf<[AnyScalar]>:$indices,
+    RankedTensorOf<[AnyScalar]>:$updates,
+    DefaultValuedAttr<IndexAttr, "0">:$axis);
   let results = (outs RankedTensorOf<[AnyScalar]>:$result);
+  let builders = [OpBuilder<
+    "mlir::OpBuilder &builder, "
+    "mlir::OperationState& result, "
+    "mlir::Type resultType, "
+    "mlir::ValueRange operands, "
+    "mlir::IntegerAttr axis"
+  >];
+
   let assemblyFormat = [{
-    $tensor $dims attr-dict `:` functional-type(operands, $result)
+    $data $indices $updates attr-dict `:` functional-type(operands, $result)
   }];
 }
 

--- a/pmlc/util/enums.td
+++ b/pmlc/util/enums.td
@@ -62,4 +62,17 @@ def DataType : I64EnumAttr<
   let convertFromStorage = "static_cast<" # returnType # ">($_self.getValue().getZExtValue())";
 }
 
+def ScatterUpdateMode : I64EnumAttr<
+    "ScatterUpdateMode",
+    "Scatter update mode",
+    [
+      I64EnumAttrCase<"sum", 0>,
+      I64EnumAttrCase<"slice", 1>,
+      I64EnumAttrCase<"elet", 2>,
+    ]> {
+  let cppNamespace = "pmlc::util";
+  let returnType = "ScatterUpdateMode";
+  let convertFromStorage = "static_cast<" # returnType # ">($_self.getValue().getZExtValue())";
+}
+
 #endif // __PML_UTIL_ENUMS__


### PR DESCRIPTION
This is just a draft to raise discussion. I simply load & add before storing into the target tensor. I tried `<pxa::PxaReduceOp>(loc, AtomicRMWKind::addf...)` but I got such an error:
```
error: 'affine.load' op index must be a dimension or symbol identifier
```
I'm not sure why but I manually tried `<mlir::ConstantIndexOp>` to use a random index as index parameter to `PxaReduceOp` and couldn't see this error.

Besides, this load & add is not optimal because the first element does not require adding, only the duplicates need that. It might need a `if...else` condition later.