### PR TITLE
Add ReduceL1 and ReduceL2

### DIFF
--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT InferenceEngineDeveloperPackage_FOUND)
   FetchContent_Declare(
     openvino
     GIT_REPOSITORY https://github.com/plaidml/openvino.git
-    GIT_TAG        2807da41b3dec2a9e6191359d7b68aaf62d0d670
+    GIT_TAG        6ff3c9a0e713c63fb81f6cb0feef326c1642a7a5
   )
   if(LOCAL_OPENVINO_DIR)
     set(openvino_SOURCE_DIR ${LOCAL_OPENVINO_DIR})

--- a/plaidml/bridge/openvino/CMakeLists.txt
+++ b/plaidml/bridge/openvino/CMakeLists.txt
@@ -26,7 +26,7 @@ if(NOT InferenceEngineDeveloperPackage_FOUND)
   FetchContent_Declare(
     openvino
     GIT_REPOSITORY https://github.com/plaidml/openvino.git
-    GIT_TAG        b6baf1ec498a68fda3afe407d6125951e0b21974
+    GIT_TAG        2807da41b3dec2a9e6191359d7b68aaf62d0d670
   )
   if(LOCAL_OPENVINO_DIR)
     set(openvino_SOURCE_DIR ${LOCAL_OPENVINO_DIR})

--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -7,6 +7,7 @@
 
 #include "ngraph/opsets/opset.hpp"
 #include "ngraph/opsets/opset1.hpp"
+#include "ngraph/opsets/opset4.hpp"
 
 #include "plaidml/op/op.h"
 
@@ -70,6 +71,24 @@ void registerReduceOps() {
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceSum>(ctx.layer);
     return edsl::make_tuple(op::sum(I, edsl::make_tuple(axes), layer->get_keep_dims()));
+  });
+
+  registerOp("ReduceL1", [](const Context& ctx) {
+    IE_ASSERT(ctx.operands.size() == 2);
+    auto I = ctx.operands.at(0);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    auto* layer = ngraph::as_type<ngraph::opset4::ReduceL1>(ctx.layer);
+    auto O = edsl::abs(op::sum(I, edsl::make_tuple(axes), layer->get_keep_dims()));
+    return edsl::make_tuple(O);
+  });
+
+  registerOp("ReduceL2", [](const Context& ctx) {
+    IE_ASSERT(ctx.operands.size() == 2);
+    auto I = ctx.operands.at(0);
+    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    auto* layer = ngraph::as_type<ngraph::opset4::ReduceL2>(ctx.layer);
+    auto O = edsl::sqrt(op::sum((I * I), edsl::make_tuple(axes), layer->get_keep_dims()));
+    return edsl::make_tuple(O);
   });
 }
 

--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -78,7 +78,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL1>(ctx.layer);
-    return edsl::make_tuple(edsl::abs(I), edsl::make_tuple(axes), layer->get_keep_dims());
+    return edsl::make_tuple(op::sum(op::abs(I), edsl::make_tuple(axes), layer->get_keep_dims()));
   });
 
   registerOp("ReduceL2", [](const Context& ctx) {
@@ -86,7 +86,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL2>(ctx.layer);
-    return edsl::make_tuple(edsl::sqrt(op::sum((I * I), edsl::make_tuple(axes), layer->get_keep_dims())));
+    return edsl::make_tuple(edsl::sqrt(op::sum(I * I, edsl::make_tuple(axes), layer->get_keep_dims())));
   });
 }
 

--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -78,8 +78,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL1>(ctx.layer);
-    auto O = edsl::abs(op::sum(I, edsl::make_tuple(axes), layer->get_keep_dims()));
-    return edsl::make_tuple(O);
+    return edsl::make_tuple(edsl::abs(I), edsl::make_tuple(axes), layer->get_keep_dims());
   });
 
   registerOp("ReduceL2", [](const Context& ctx) {
@@ -87,8 +86,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL2>(ctx.layer);
-    auto O = edsl::sqrt(op::sum((I * I), edsl::make_tuple(axes), layer->get_keep_dims()));
-    return edsl::make_tuple(O);
+    return edsl::make_tuple(edsl::sqrt(op::sum((I * I), edsl::make_tuple(axes), layer->get_keep_dims())));
   });
 }
 

--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -5,7 +5,6 @@
 #include "plaidml_ops.hpp"
 #include "plaidml_util.hpp"
 
-#include "ngraph/opsets/opset.hpp"
 #include "ngraph/opsets/opset1.hpp"
 #include "ngraph/opsets/opset4.hpp"
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/reduce_ops.hpp"
+
+using LayerTestsDefinitions::ReduceOpsLayerTest;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+    std::vector<size_t>{1, 2, 4, 4},
+    std::vector<size_t>{3, 2, 5, 6},
+};
+
+const std::vector<std::vector<int>> axes = {{0, 2}, {1, 3}};
+
+std::vector<CommonTestUtils::OpType> opTypes = {
+    CommonTestUtils::OpType::SCALAR,  //
+    CommonTestUtils::OpType::VECTOR,  //
+};
+
+const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
+    // TODO(Liyang): LogicalAnd, LogicalOr, L1 fail tests, need fix
+    //    ngraph::helpers::ReductionType::LogicalAnd,  //
+    //    ngraph::helpers::ReductionType::LogicalOr,   //
+    ngraph::helpers::ReductionType::Mean,  //
+    ngraph::helpers::ReductionType::Min,   //
+    ngraph::helpers::ReductionType::Max,   //
+    ngraph::helpers::ReductionType::Sum,   //
+    ngraph::helpers::ReductionType::Prod,  //
+    //    ngraph::helpers::ReductionType::L1,          //
+    ngraph::helpers::ReductionType::L2,  //
+};
+
+const auto paramsOneAxis = testing::Combine(testing::Values(std::vector<int>{0}),  //
+                                            testing::ValuesIn(opTypes),            //
+                                            testing::Values(true, false),          //
+                                            testing::ValuesIn(reductionTypes),     //
+                                            testing::ValuesIn(netPrecisions),      //
+                                            testing::ValuesIn(inputShapes),        //
+                                            testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(ReduceOneAxis, ReduceOpsLayerTest, paramsOneAxis, ReduceOpsLayerTest::getTestCaseName);
+
+const auto params = testing::Combine(testing::ValuesIn(axes),            //
+                                     testing::Values(opTypes[1]),        //
+                                     testing::Values(true, false),       //
+                                     testing::ValuesIn(reductionTypes),  //
+                                     testing::ValuesIn(netPrecisions),   //
+                                     testing::ValuesIn(inputShapes),     //
+                                     testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(Reduce, ReduceOpsLayerTest, params, ReduceOpsLayerTest::getTestCaseName);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -13,12 +13,31 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
 };
 
+const std::vector<bool> keepDims = {
+    true,
+    false,
+};
+
 const std::vector<std::vector<size_t>> inputShapes = {
     std::vector<size_t>{1, 2, 4, 4},
     std::vector<size_t>{3, 2, 5, 6},
 };
 
-const std::vector<std::vector<int>> axes = {{0, 2}, {1, 3}};
+const std::vector<std::vector<int>> axes = {{0}, {1}, {2}, {3}};
+
+const std::vector<std::vector<int>> axesND = {
+    {0, 1},       //
+    {0, 2},       //
+    {0, 3},       //
+    {1, 2},       //
+    {1, 3},       //
+    {2, 3},       //
+    {0, 1, 2},    //
+    {0, 1, 3},    //
+    {0, 2, 3},    //
+    {1, 2, 3},    //
+    {0, 1, 2, 3}  //
+};
 
 std::vector<CommonTestUtils::OpType> opTypes = {
     CommonTestUtils::OpType::SCALAR,  //
@@ -35,9 +54,14 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
     ngraph::helpers::ReductionType::L2,    //
 };
 
-const auto paramSmoke = testing::Combine(testing::Values(std::vector<int>{0}),               //
+const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
+    ngraph::helpers::ReductionType::LogicalOr,   //
+    ngraph::helpers::ReductionType::LogicalAnd,  //
+};
+
+const auto paramSmoke = testing::Combine(testing::Values(axes[0]),                           //
                                          testing::Values(CommonTestUtils::OpType::VECTOR),   //
-                                         testing::Values(false),                             //
+                                         testing::Values(keepDims[1]),                       //
                                          testing::ValuesIn(reductionTypes),                  //
                                          testing::Values(InferenceEngine::Precision::FP32),  //
                                          testing::Values(std::vector<size_t>{1, 2, 4, 4}),   //
@@ -45,23 +69,23 @@ const auto paramSmoke = testing::Combine(testing::Values(std::vector<int>{0}),  
 
 INSTANTIATE_TEST_CASE_P(smoke, ReduceOpsLayerTest, paramSmoke, ReduceOpsLayerTest::getTestCaseName);
 
-const auto paramsOneAxis = testing::Combine(testing::Values(std::vector<int>{0}),  //
-                                            testing::ValuesIn(opTypes),            //
-                                            testing::Values(true, false),          //
-                                            testing::ValuesIn(reductionTypes),     //
-                                            testing::ValuesIn(netPrecisions),      //
-                                            testing::ValuesIn(inputShapes),        //
+const auto paramsOneAxis = testing::Combine(testing::ValuesIn(axes),            //
+                                            testing::Values(opTypes[1]),        //
+                                            testing::ValuesIn(keepDims),        //
+                                            testing::ValuesIn(reductionTypes),  //
+                                            testing::ValuesIn(netPrecisions),   //
+                                            testing::ValuesIn(inputShapes),     //
                                             testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
 INSTANTIATE_TEST_CASE_P(ReduceOneAxis, ReduceOpsLayerTest, paramsOneAxis, ReduceOpsLayerTest::getTestCaseName);
 
-const auto params = testing::Combine(testing::ValuesIn(axes),            //
-                                     testing::Values(opTypes[1]),        //
-                                     testing::Values(true, false),       //
-                                     testing::ValuesIn(reductionTypes),  //
-                                     testing::ValuesIn(netPrecisions),   //
-                                     testing::ValuesIn(inputShapes),     //
-                                     testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+const auto paramsMultiAxis = testing::Combine(testing::ValuesIn(axesND),          //
+                                              testing::Values(opTypes[1]),        //
+                                              testing::Values(keepDims[0]),       //
+                                              testing::ValuesIn(reductionTypes),  //
+                                              testing::ValuesIn(netPrecisions),   //
+                                              testing::ValuesIn(inputShapes),     //
+                                              testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-INSTANTIATE_TEST_CASE_P(Reduce, ReduceOpsLayerTest, params, ReduceOpsLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(ReduceMultiAxis, ReduceOpsLayerTest, paramsMultiAxis, ReduceOpsLayerTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -54,38 +54,40 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
     ngraph::helpers::ReductionType::L2,    //
 };
 
+// TODO: ReduceLogicalAnd and ReduceLogicalOr require Boolean datatype which seems not well supported.
+//  Should add test for Logical reduce Type later
 const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
     ngraph::helpers::ReductionType::LogicalOr,   //
     ngraph::helpers::ReductionType::LogicalAnd,  //
 };
 
-const auto paramSmoke = testing::Combine(testing::Values(axes[0]),                           //
-                                         testing::Values(CommonTestUtils::OpType::VECTOR),   //
-                                         testing::Values(keepDims[1]),                       //
-                                         testing::ValuesIn(reductionTypes),                  //
-                                         testing::Values(InferenceEngine::Precision::FP32),  //
-                                         testing::Values(std::vector<size_t>{1, 2, 4, 4}),   //
-                                         testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+INSTANTIATE_TEST_CASE_P(ReduceOneAxis, ReduceOpsLayerTest,
+                        ::testing::Combine(testing::ValuesIn(axes),            //
+                                           testing::ValuesIn(opTypes),         //
+                                           testing::ValuesIn(keepDims),        //
+                                           testing::ValuesIn(reductionTypes),  //
+                                           testing::ValuesIn(netPrecisions),   //
+                                           testing::ValuesIn(inputShapes),     //
+                                           testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ReduceOpsLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(smoke, ReduceOpsLayerTest, paramSmoke, ReduceOpsLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(ReduceMultiAxis, ReduceOpsLayerTest,
+                        ::testing::Combine(testing::ValuesIn(axesND),          //
+                                           testing::ValuesIn(opTypes),         //
+                                           testing::ValuesIn(keepDims),        //
+                                           testing::ValuesIn(reductionTypes),  //
+                                           testing::ValuesIn(netPrecisions),   //
+                                           testing::ValuesIn(inputShapes),     //
+                                           testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ReduceOpsLayerTest::getTestCaseName);
 
-const auto paramsOneAxis = testing::Combine(testing::ValuesIn(axes),            //
-                                            testing::Values(opTypes[1]),        //
-                                            testing::ValuesIn(keepDims),        //
-                                            testing::ValuesIn(reductionTypes),  //
-                                            testing::ValuesIn(netPrecisions),   //
-                                            testing::ValuesIn(inputShapes),     //
-                                            testing::Values(CommonTestUtils::DEVICE_PLAIDML));
-
-INSTANTIATE_TEST_CASE_P(ReduceOneAxis, ReduceOpsLayerTest, paramsOneAxis, ReduceOpsLayerTest::getTestCaseName);
-
-const auto paramsMultiAxis = testing::Combine(testing::ValuesIn(axesND),          //
-                                              testing::Values(opTypes[1]),        //
-                                              testing::Values(keepDims[0]),       //
-                                              testing::ValuesIn(reductionTypes),  //
-                                              testing::ValuesIn(netPrecisions),   //
-                                              testing::ValuesIn(inputShapes),     //
-                                              testing::Values(CommonTestUtils::DEVICE_PLAIDML));
-
-INSTANTIATE_TEST_CASE_P(ReduceMultiAxis, ReduceOpsLayerTest, paramsMultiAxis, ReduceOpsLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke, ReduceOpsLayerTest,
+                        ::testing::Combine(testing::Values(axes[0]),                          //
+                                           testing::Values(CommonTestUtils::OpType::VECTOR),  //
+                                           testing::Values(keepDims[1]),                      //
+                                           testing::ValuesIn(reductionTypes),                 //
+                                           testing::Values(netPrecisions[0]),                 //
+                                           testing::Values(std::vector<size_t>{1, 2, 4, 4}),  //
+                                           testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+                        ReduceOpsLayerTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -26,17 +26,24 @@ std::vector<CommonTestUtils::OpType> opTypes = {
 };
 
 const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
-    // TODO(Liyang): LogicalAnd, LogicalOr, L1 fail tests, need fix
-    //    ngraph::helpers::ReductionType::LogicalAnd,  //
-    //    ngraph::helpers::ReductionType::LogicalOr,   //
     ngraph::helpers::ReductionType::Mean,  //
     ngraph::helpers::ReductionType::Min,   //
     ngraph::helpers::ReductionType::Max,   //
     ngraph::helpers::ReductionType::Sum,   //
     ngraph::helpers::ReductionType::Prod,  //
-    //    ngraph::helpers::ReductionType::L1,          //
-    ngraph::helpers::ReductionType::L2,  //
+    ngraph::helpers::ReductionType::L1,    //
+    ngraph::helpers::ReductionType::L2,    //
 };
+
+const auto paramSmoke = testing::Combine(testing::Values(std::vector<int>{0}),               //
+                                         testing::Values(CommonTestUtils::OpType::VECTOR),   //
+                                         testing::Values(false),                             //
+                                         testing::ValuesIn(reductionTypes),                  //
+                                         testing::Values(InferenceEngine::Precision::FP32),  //
+                                         testing::Values(std::vector<size_t>{1, 2, 4, 4}),   //
+                                         testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(smoke, ReduceOpsLayerTest, paramSmoke, ReduceOpsLayerTest::getTestCaseName);
 
 const auto paramsOneAxis = testing::Combine(testing::Values(std::vector<int>{0}),  //
                                             testing::ValuesIn(opTypes),            //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -54,8 +54,7 @@ const std::vector<ngraph::helpers::ReductionType> reductionTypes = {
     ngraph::helpers::ReductionType::L2,    //
 };
 
-// TODO: ReduceLogicalAnd and ReduceLogicalOr require Boolean datatype which seems not well supported.
-//  Should add test for Logical reduce Type later
+// ReduceLogicalAnd and ReduceLogicalOr require Boolean datatype which seems not well supported.
 const std::vector<ngraph::helpers::ReductionType> reductionLogicalTypes = {
     ngraph::helpers::ReductionType::LogicalOr,   //
     ngraph::helpers::ReductionType::LogicalAnd,  //
@@ -82,12 +81,12 @@ INSTANTIATE_TEST_CASE_P(ReduceMultiAxis, ReduceOpsLayerTest,
                         ReduceOpsLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(smoke, ReduceOpsLayerTest,
-                        ::testing::Combine(testing::Values(axes[0]),                          //
-                                           testing::Values(CommonTestUtils::OpType::VECTOR),  //
-                                           testing::Values(keepDims[1]),                      //
-                                           testing::ValuesIn(reductionTypes),                 //
-                                           testing::Values(netPrecisions[0]),                 //
-                                           testing::Values(std::vector<size_t>{1, 2, 4, 4}),  //
+                        ::testing::Combine(testing::Values(axes[0]),                           //
+                                           testing::Values(CommonTestUtils::OpType::VECTOR),   //
+                                           testing::Values(false),                             //
+                                           testing::ValuesIn(reductionTypes),                  //
+                                           testing::Values(InferenceEngine::Precision::FP32),  //
+                                           testing::Values(std::vector<size_t>{1, 2, 4, 4}),   //
                                            testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
                         ReduceOpsLayerTest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
For testing, it need `ngraph::helper::ReductionType::L1` and `ngraph::helper::ReductionType::L2` which are only in OpenVINO upstream now.
I will update them into Flex-plaidml-team/openvino for temprary tests.