### PR TITLE
WIP: Add L0 profiling

### DIFF
--- a/pmlc/rt/level_zero/level_zero_utils.h
+++ b/pmlc/rt/level_zero/level_zero_utils.h
@@ -132,9 +132,10 @@ public:
   zeEventPool();
   ~zeEventPool();
 
-  void
-  InitEventPool(ze_context_handle_t context, uint32_t count,
-                ze_event_pool_flags_t flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE);
+  void InitEventPool(
+      ze_context_handle_t context, uint32_t count,
+      ze_event_pool_flags_t flags = (ZE_EVENT_POOL_FLAG_HOST_VISIBLE |
+                                     ZE_EVENT_POOL_FLAG_KERNEL_TIMESTAMP));
 
   void create_event(ze_event_handle_t &event, ze_event_scope_flags_t signal = 0,
                     ze_event_scope_flags_t wait = 0);


### PR DESCRIPTION
Need further check on how to produce `Total Level Zero time`, and each time value correctness.

- [ ] Total Level Zero time
- [x] Submit Command Buffer time cost

Example L0 profiling output is:
```shell
2020-12-30 16:23:18,830 VERBOSE-1 [default] Total Level Zero execution time: 55.9286ms
2020-12-30 16:23:18,830 VERBOSE-1 [default] Total Level Zero Kernels: 97
2020-12-30 16:23:18,830 VERBOSE-1 [default] Total Level Zero Kernel execution time: 40.1342ms
2020-12-30 16:23:18,830 VERBOSE-1 [default] Total Level Zero memory transfers: 305
2020-12-30 16:23:18,830 VERBOSE-1 [default] Total Level Zero memory transfer time: 15.7944ms
2020-12-30 16:23:18,830 VERBOSE-1 [default] Execution time: 10484ms
Example finished, elapsed: 0.015s (compile), 10.485s (execution)

-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS          
-----------------------------------------------------------------------------------------
resnet50             55.93 ms                  55.93 ms / 17.88 fps
Correctness: PASS, max_error: 1.3132991625752766e-05, max_abs_error: 1.5050172805786133e-06, fail_ratio: 0.0
{'backend': 'plaid',
 'batch_size': 1,
 'compile_duration': 0.014580726623535156,
 'correct': True,
 'duration_per_example': 0.055928637,
 'examples': 1,
 'fail_ratio': 0.0,
 'max_abs_error': 1.5050172805786133e-06,
 'max_error': 1.3132991625752766e-05,
 'model': 'resnet50',
 'tile_duration_per_example': 0.055928637}

``` 
For reference, OpenCL profiling output is 
```shell
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL time: 10445.6ms
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL execute time: 57.301ms
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL kernels: 97
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL kernel execute time: 42.2656ms
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL memory transfers: 305
2020-12-30 15:45:06,688 VERBOSE-1 [default] Total OpenCL memory transfer time: 15.0353ms
2020-12-30 15:45:06,688 VERBOSE-1 [default] Execution time: 10527ms
Example finished, elapsed: 0.014s (compile), 10.528s (execution)

-----------------------------------------------------------------------------------------
Network Name         Inference Latency         Time / FPS          
-----------------------------------------------------------------------------------------
resnet50             57.30 ms                  57.30 ms / 17.45 fps
Correctness: PASS, max_error: 1.3132991625752766e-05, max_abs_error: 1.5050172805786133e-06, fail_ratio: 0.0
{'backend': 'plaid',
 'batch_size': 1,
 'compile_duration': 0.014423370361328125,
 'correct': True,
 'duration_per_example': 0.057300957,
 'examples': 1,
 'fail_ratio': 0.0,
 'max_abs_error': 1.5050172805786133e-06,
 'max_error': 1.3132991625752766e-05,
 'model': 'resnet50',
 'tile_duration_per_example': 0.057300957}

```

