### PR TITLE
fix test case for Lrn, MatMul, Pooling

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lrn.cpp
@@ -16,31 +16,24 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
-};
-
-const std::vector<std::vector<int64_t>> axes = {
-    {1},
-    {2, 3},
+    // InferenceEngine::Precision::FP16,
 };
 
 const double alpha = 9.9e-05;
 const double beta = 2;
 const double bias = 1.0;
 const size_t size = 5;
-/*
-INSTANTIATE_TEST_CASE_P(smoke_LrnCheck, LrnLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke, LrnLayerTest,
                         ::testing::Combine(                                              //
                             ::testing::Values(alpha),                                    //
                             ::testing::Values(beta),                                     //
                             ::testing::Values(bias),                                     //
                             ::testing::Values(size),                                     //
-                            ::testing::ValuesIn(axes),                                   //
+                            ::testing::Values(std::vector<int64_t>({1})),                //
                             ::testing::ValuesIn(netPrecisions),                          //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
                             ::testing::Values(std::vector<size_t>({10, 10, 3, 2})),      //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         LrnLayerTest::getTestCaseName);
-*/
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -6,35 +6,38 @@
 
 #include "single_layer_tests/mat_mul.hpp"
 
-using namespace LayerTestsDefinitions;
+using LayerTestsDefinitions::MatMulTest;
 
 namespace {
-/*
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
-    InferenceEngine::Precision::FP32,
-};
 
-const std::vector<ShapeRelatedParams> shapeRelatedParams = {
-    {{{1, 4, 5, 6}, false}, {{1, 4, 6, 4}, false}},
-};
+// TODO: Something very weird here
 
-std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
-    ngraph::helpers::InputLayerType::CONSTANT,
-    ngraph::helpers::InputLayerType::PARAMETER,
-};
+// const std::vector<InferenceEngine::Precision> inputPrecisions = {
+//         InferenceEngine::Precision::FP32
+// };
 
-std::map<std::string, std::string> additional_config = {};
+// const std::vector<std::vector<size_t>> shapesA = {
+//         {1, 4, 5, 6}
+// };
 
-INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
-                        ::testing::Combine(                                              //
-                            ::testing::ValuesIn(shapeRelatedParams),                     //
-                            ::testing::ValuesIn(inputPrecisions),                        //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::ValuesIn(secondaryInputTypes),                    //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
-                            ::testing::Values(additional_config)),                       //
-                        MatMulTest::getTestCaseName);
-*/
+// const std::vector<std::vector<size_t>> shapesB = {
+//         {1, 4, 6, 4}
+// };
+
+// std::vector<ngraph::helpers::InputLayerType> secondaryInputTypes = {
+//         ngraph::helpers::InputLayerType::CONSTANT,
+//         ngraph::helpers::InputLayerType::PARAMETER,
+// };
+
+// INSTANTIATE_TEST_CASE_P(MatMul, MatMulTest,
+//         ::testing::Combine(
+//                 ::testing::ValuesIn(inputPrecisions),
+//                 ::testing::ValuesIn(shapesA),
+//                 ::testing::ValuesIn(shapesB),
+//                 ::testing::Values(false),
+//                 ::testing::Values(false),
+//                 ::testing::ValuesIn(secondaryInputTypes),
+//                 ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+//         MatMulTest::getTestCaseName);
+
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pooling_smoke.cpp
@@ -3,37 +3,33 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+// Simplified pooling tests, suitable for CI. The main pooling tests are long and include errors in the reference
+// implementation
+
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
 #include "single_layer_tests/pooling.hpp"
 
-using namespace LayerTestsDefinitions;
+using LayerTestsDefinitions::PoolingLayerTest;
+using LayerTestsDefinitions::poolSpecificParams;
 
 namespace {
 // Common params
-const std::vector<InferenceEngine::Precision> inputPrecisions = {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
 };
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP16,
-};
-
 const std::vector<std::vector<size_t>> kernels = {
-    {3, 3},
     {3, 5},
 };
 const std::vector<std::vector<size_t>> strides = {
     {1, 1},
-    {1, 2},
 };
 const std::vector<std::vector<size_t>> padBegins = {
-    {0, 0},
     {0, 2},
 };
 const std::vector<std::vector<size_t>> padEnds = {
-    {0, 0},
     {0, 2},
 };
 const std::vector<ngraph::op::RoundingType> roundingTypes = {
@@ -41,124 +37,51 @@ const std::vector<ngraph::op::RoundingType> roundingTypes = {
     ngraph::op::RoundingType::FLOOR,
 };
 ////* ========== Max Polling ========== */
-/* +========== Explicit Pad Floor Rounding ========== */
-const auto maxPool_ExplicitPad_FloorRounding_Params = ::testing::Combine(  //
-    ::testing::Values(ngraph::helpers::PoolingTypes::MAX),                 //
-    ::testing::ValuesIn(kernels),                                          //
-    ::testing::ValuesIn(strides),                                          //
-    ::testing::ValuesIn(padBegins),                                        //
-    ::testing::ValuesIn(padEnds),                                          //
-    ::testing::Values(ngraph::op::RoundingType::FLOOR),                    //
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),                      //
-    ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
-);
-/*
-INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_FloorRpunding, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            maxPool_ExplicitPad_FloorRounding_Params,                    //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+const auto MaxPoolSmokeParams =
+    ::testing::Combine(::testing::Values(ngraph::helpers::PoolingTypes::MAX),  //
+                       ::testing::ValuesIn(kernels),                           //
+                       ::testing::ValuesIn(strides),                           //
+                       ::testing::ValuesIn(padBegins),                         //
+                       ::testing::ValuesIn(padEnds),                           //
+                       ::testing::ValuesIn(roundingTypes),                     //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT),       //
+                       ::testing::Values(false));  // placeholder value - exclude pad not applicable for max pooling
+
+INSTANTIATE_TEST_CASE_P(smoke_MaxPool, PoolingLayerTest,
+                        ::testing::Combine(MaxPoolSmokeParams,                                          //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                                           ::testing::Values(InferenceEngine::Layout::ANY),             //
+                                           ::testing::Values(InferenceEngine::Layout::ANY),             //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
-*/
-/* ========== Explicit Pad Ceil Rounding ========== */
-const auto maxPool_ExplicitPad_CeilRounding_Params = ::testing::Combine(  //
-    ::testing::Values(ngraph::helpers::PoolingTypes::MAX),                //
-    ::testing::ValuesIn(kernels),                                         //
-    ::testing::ValuesIn(strides),                                         //
-    ::testing::ValuesIn(padBegins),                                       //
-    ::testing::ValuesIn(padEnds),                                         //
-    ::testing::Values(ngraph::op::RoundingType::CEIL),                    //
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),                     //
-    ::testing::Values(false)  // placeholder value - exclude pad not applicable for max pooling
-);
-/*
-INSTANTIATE_TEST_CASE_P(smoke_MaxPool_ExplicitPad_CeilRpunding, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            maxPool_ExplicitPad_CeilRounding_Params,                     //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-                        PoolingLayerTest::getTestCaseName);
-*/
+
 ////* ========== Avg Pooling ========== */
-/* +========== Explicit Pad Ceil Rounding ========== */
-const auto avgPoolExplicitPadCeilRoundingParams = ::testing::Combine(  //
-    ::testing::Values(ngraph::helpers::PoolingTypes::AVG),             //
-    ::testing::ValuesIn(kernels),                                      //
-    // TODO: Non 1 strides fails in ngraph reference implementation with error "The end corner is out of bounds at axis
-    // 3" thrown in the test body.
-    ::testing::ValuesIn(strides),                                                     //
-    ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}, {0, 1}})),  //
-    ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}, {0, 1}})),  //
-    ::testing::Values(ngraph::op::RoundingType::CEIL),                                //
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),                                 //
-    ::testing::Values(true, false)                                                    //
-);
-/*
-INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            avgPoolExplicitPadCeilRoundingParams,                        //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-                        PoolingLayerTest::getTestCaseName);
-*/
-std::vector<poolSpecificParams> psParams(
-    {poolSpecificParams(ngraph::helpers::PoolingTypes::AVG, {2, 2}, {2, 2}, {0, 0}, {0, 0},
-                        ngraph::op::RoundingType::CEIL, ngraph::op::PadType::EXPLICIT, false),
-     poolSpecificParams(ngraph::helpers::PoolingTypes::AVG, {7, 7}, {1, 1}, {0, 0}, {1, 1},
-                        ngraph::op::RoundingType::CEIL, ngraph::op::PadType::EXPLICIT, false)});
-/*
-INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_CeilRounding_corner, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            ::testing::ValuesIn(psParams),                               //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 1024, 6, 6})),     //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
-                        PoolingLayerTest::getTestCaseName);
-*/
+
 /* +========== Explicit Pad Floor Rounding ========== */
-const auto avgPoolExplicitPadFloorRoundingParams = ::testing::Combine(        //
-    ::testing::Values(ngraph::helpers::PoolingTypes::AVG),                    //
-    ::testing::ValuesIn(kernels),                                             //
-    ::testing::ValuesIn(strides),                                             //
-    ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}})),  //
-    ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}})),  //
-    ::testing::Values(ngraph::op::RoundingType::FLOOR),                       //
-    ::testing::Values(ngraph::op::PadType::EXPLICIT),                         //
-    ::testing::Values(true, false)                                            //
-);
-/*
-INSTANTIATE_TEST_CASE_P(smoke_AvgPool_ExplicitPad_FloorRounding, PoolingLayerTest,
-                        ::testing::Combine(                                              //
-                            avgPoolExplicitPadFloorRoundingParams,                       //
-                            ::testing::ValuesIn(netPrecisions),                          //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(InferenceEngine::Layout::ANY),             //
-                            ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
-                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),
+const auto avgPoolSmokeParams =
+    ::testing::Combine(::testing::Values(ngraph::helpers::PoolingTypes::AVG),                    //
+                       ::testing::ValuesIn(kernels),                                             //
+                       ::testing::ValuesIn(strides),                                             //
+                       ::testing::ValuesIn(padBegins),                                           //
+                       ::testing::ValuesIn(std::vector<std::vector<size_t>>({{0, 0}, {1, 1}})),  //
+                       ::testing::ValuesIn(roundingTypes),                                       //
+                       ::testing::Values(ngraph::op::PadType::EXPLICIT),                         //
+                       ::testing::Values(true, false));                                          //
+
+INSTANTIATE_TEST_CASE_P(smoke_AvgPool, PoolingLayerTest,
+                        ::testing::Combine(avgPoolSmokeParams,                                          //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                                           ::testing::Values(InferenceEngine::Layout::ANY),             //
+                                           ::testing::Values(InferenceEngine::Layout::ANY),             //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),      //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         PoolingLayerTest::getTestCaseName);
-*/
-////* ========== Avg and Max Polling Cases ========== */
+
 /*    ========== Valid Pad Rounding Not Applicable ========== */
 const auto allPools_ValidPad_Params = ::testing::Combine(                                       //
     ::testing::Values(ngraph::helpers::PoolingTypes::MAX, ngraph::helpers::PoolingTypes::AVG),  //
@@ -172,7 +95,7 @@ const auto allPools_ValidPad_Params = ::testing::Combine(                       
     ::testing::Values(false)                        // placeholder value - exclude pad not applicable for max pooling
 );
 
-INSTANTIATE_TEST_CASE_P(smoke_MAX_and_AVGPool_ValidPad, PoolingLayerTest,
+INSTANTIATE_TEST_CASE_P(smoke_BothPool, PoolingLayerTest,
                         ::testing::Combine(                                              //
                             allPools_ValidPad_Params,                                    //
                             ::testing::ValuesIn(netPrecisions),                          //


### PR DESCRIPTION
I take test cases in plaidml-v1 as references. Notes for each cases are listed below:

- Lrn: keep only one item of `axes` parameter as plaidml-v1 does. Rename `smoke_LrnCheck` to `smoke` for integrity.
- MatMul: Keep all cases commented out because there's a comment in plaidml-v1 saying that:
> // TODO: Something very weird here
- Pooling: Rename those cases to be the same as plaidml-v1's. Add those missing cases that were in plaidml-v1 and remove those weren't. See its commnet:
> // Simplified pooling tests, suitable for CI. The main pooling tests are long and include errors in the reference implementation