### PR TITLE
change decrease mode to accord with ngraph reference mode.

### DIFF
--- a/plaidml/bridge/openvino/ops/reorg_yolo.cpp
+++ b/plaidml/bridge/openvino/ops/reorg_yolo.cpp
@@ -21,7 +21,7 @@ void registerReorgYolo() {
     auto I = ctx.operands.at(0);
     // as openvino op request, the strides have to be divisible by 'H' and 'W'.
     auto strides = layer->get_strides()[0];
-    return edsl::make_tuple(op::reorg_yolo(I, strides, false));
+    return edsl::make_tuple(op::reorg_yolo(I, strides, true));
   });
 }
 


### PR DESCRIPTION
please reference openvino PR https://github.com/Flex-plaidml-team/openvino/pull/28.

if we change the `decrease` mode parameter of reorg_yolo op which is from plaidml oplib, then after merging the PR https://github.com/Flex-plaidml-team/openvino/pull/28, it will pass all the test case.