### PR TITLE
Fix squeeze op 

### DIFF
--- a/plaidml/bridge/openvino/ops/squeeze.cpp
+++ b/plaidml/bridge/openvino/ops/squeeze.cpp
@@ -20,9 +20,7 @@ void registerSqueeze() {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
     auto axes = get_constant_vector<int>(1, ctx.layer);
-    std::vector<int> v_axes;
-    v_axes.assign(axes.begin(), axes.end());
-    return edsl::make_tuple(op::squeeze(I, v_axes));
+    return edsl::make_tuple(op::squeeze(I, axes));
   });
 }
 

--- a/plaidml/bridge/openvino/ops/squeeze.cpp
+++ b/plaidml/bridge/openvino/ops/squeeze.cpp
@@ -19,7 +19,7 @@ void registerSqueeze() {
   registerOp("squeeze", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    auto axes = get_axis_set_from_constant_operand(1, ctx.layer);
+    auto axes = get_constant_vector<int>(1, ctx.layer);
     std::vector<int> v_axes;
     v_axes.assign(axes.begin(), axes.end());
     return edsl::make_tuple(op::squeeze(I, v_axes));

--- a/plaidml/bridge/openvino/plaidml_util.cpp
+++ b/plaidml/bridge/openvino/plaidml_util.cpp
@@ -4,8 +4,6 @@
 
 #include "plaidml_util.hpp"
 
-#include "ngraph/op/constant.hpp"
-
 #include "plaidml/edsl/edsl.h"
 
 using namespace plaidml;          // NOLINT[build/namespaces]

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -17,6 +17,8 @@
 #include "ngraph/op/util/attr_types.hpp"
 #include "ngraph/shape.hpp"
 #include "ngraph/type/element_type.hpp"
+#include "ngraph/op/constant.hpp"
+
 
 #include "plaidml/edsl/edsl.h"
 #include "plaidml/op/op.h"
@@ -36,5 +38,15 @@ ngraph::Coordinate get_coords_from_constant_operand(size_t operand_idx, ngraph::
 
 plaidml::edsl::Tensor clip_activation(const std::string& func_name, bool should_clip, float clip,
                                       const plaidml::edsl::Tensor& T);
+
+template <typename T>
+std::vector<T> get_constant_vector(size_t operand_idx, ngraph::Node* layer){
+  auto* vector_ngraph_op = ngraph::as_type<ngraph::op::Constant>(layer->get_input_node_ptr(operand_idx));
+  if (vector_ngraph_op) {
+    return vector_ngraph_op->get_vector<T>();
+  } else {
+    THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
+  }
+}
 
 }  // namespace PlaidMLPlugin

--- a/plaidml/bridge/openvino/plaidml_util.hpp
+++ b/plaidml/bridge/openvino/plaidml_util.hpp
@@ -45,7 +45,7 @@ std::vector<T> get_constant_vector(size_t operand_idx, ngraph::Node* layer){
   if (vector_ngraph_op) {
     return vector_ngraph_op->get_vector<T>();
   } else {
-    THROW_IE_EXCEPTION << "Dynamic axis not currently supported by PlaidML plugin";
+    THROW_IE_EXCEPTION << "Dynamic vector not currently supported by PlaidML plugin";
   }
 }
 


### PR DESCRIPTION
the squeeze failed test case is cause by the `get_axis_set_from_constant_operand()`  in `plaidml_util.cpp`. so I add `get_constant_vector<>` template function to solve this problem.

note:
when we build a constant node in openvino `setup`, it could be any type data. but for now, when we get the constant data by using plaidml_util functions. it only have `shape, Coordinate, AxisSet, AxisVector`, those data Type are inherited from `vector<size_t>`.
it may solve the worry constant data. so I suggest that we should always use the `get_constant_vector` function when we know the constant data type isn't `shape, Coordinate, AxisSet, AxisVector`.