### PR TITLE
fix MatMul op and enable test cases

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -9,7 +9,6 @@
 using namespace LayerTestsDefinitions;
 
 namespace {
-/*
 const std::vector<InferenceEngine::Precision> inputPrecisions = {
     InferenceEngine::Precision::FP32,
 };
@@ -36,5 +35,4 @@ INSTANTIATE_TEST_CASE_P(smoke_MatMul, MatMulTest,
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
                             ::testing::Values(additional_config)),                       //
                         MatMulTest::getTestCaseName);
-*/
 }  // namespace


### PR DESCRIPTION
Note: MatMul op performs the same functionality as `batch_dot` dose. They take the leading dimensions as batch and the last two dimensions to do matrix multiplication. This is different with `op::dot` which does matrix multiplication on the last two dimensions but also does permutation on the leading dimensions. For example:
```
A -> <7x8x9x3x4>
B -> <7x8x9x4x6>
C -> <5x4x2>
matmul(A, B) -> <7x8x9x3x6> Leading batch 7x8x9
dot(A, B) -> <7x8x9x3x7x8x9x6>
matmul(A, C) -> Error: leading dimensions mismatch
dot(A, C) -> <7x8x9x3x5x2>
```