### PR TITLE
Fix ReduceOps

### DIFF
--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -21,6 +21,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalAnd>(ctx.layer);
+    I = edsl::cast(I, DType::FLOAT32);
     return edsl::make_tuple(op::all(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
 
@@ -29,6 +30,7 @@ void registerReduceOps() {
     auto I = ctx.operands.at(0);
     std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalOr>(ctx.layer);
+    I = edsl::cast(I, DType::FLOAT32);
     return edsl::make_tuple(op::any(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
 

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1613,21 +1613,6 @@ TEST_F(CppEdsl, Pow) {
   checkClose(program, {A_input, B_input}, {expected});
 }
 
-TEST_F(CppEdsl, logicalAnd) {
-  auto A = Placeholder(DType::FLOAT32, {3, 3});
-  std::vector<int> axes = {1};
-  auto O = cast(op::all(A, edsl::make_tuple(axes), false), DType::INT8);
-  auto program = makeProgram("logicaland", {A}, {O});
-
-  std::vector<float> A_input = {
-      0, 1, 2,  //
-      3, 4, 5,  //
-      6, 7, 8,  //
-  };
-  std::vector<int8_t> expected = {0, 1, 1};
-  checkClose(program, {A_input}, {expected});
-}
-
 TEST_F(CppEdsl, Round) {
   auto S = Placeholder(DType::FLOAT32, {3, 3});
   auto O = round(S);

--- a/plaidml/edsl/tests/edsl_test.cc
+++ b/plaidml/edsl/tests/edsl_test.cc
@@ -1613,6 +1613,21 @@ TEST_F(CppEdsl, Pow) {
   checkClose(program, {A_input, B_input}, {expected});
 }
 
+TEST_F(CppEdsl, logicalAnd) {
+  auto A = Placeholder(DType::FLOAT32, {3, 3});
+  std::vector<int> axes = {1};
+  auto O = cast(op::all(A, edsl::make_tuple(axes), false), DType::INT8);
+  auto program = makeProgram("logicaland", {A}, {O});
+
+  std::vector<float> A_input = {
+      0, 1, 2,  //
+      3, 4, 5,  //
+      6, 7, 8,  //
+  };
+  std::vector<int8_t> expected = {0, 1, 1};
+  checkClose(program, {A_input}, {expected});
+}
+
 TEST_F(CppEdsl, Round) {
   auto S = Placeholder(DType::FLOAT32, {3, 3});
   auto O = round(S);


### PR DESCRIPTION
From IR, it can be found that ngraph will give plaidml `i1` datatype tensor,
```
module @Reduce {
  func @main(%arg0: tensor<3x3xi1>, %arg1: tensor<1xsi64> {tile.const = 0 : index}) -> tensor<3xf32> {
    %0 = layer.box "ng.ReduceLogicalAnd" (%arg2, %arg3) = (%arg0, %arg1) : (tensor<3x3xi1>, tensor<1xsi64>) -> tensor<3xui8> {
      %c1 = tile.constant(1 : i64) : tensor<i1>
      %c0 = tile.constant(0 : i64) : tensor<!tile.six>
      %2 = tile.cmp_eq %arg2, %c0 : (tensor<3x3xi1>, tensor<!tile.six>) -> tensor<3x3xi1>
      %c0_0 = tile.constant(0 : i64) : tensor<!tile.six>
      %3 = tile.cast %c0_0 : (tensor<!tile.six>) -> tensor<i1>
      %c1_1 = tile.constant(1 : i64) : tensor<!tile.six>
      %4 = tile.cast %c1_1 : (tensor<!tile.six>) -> tensor<i1>
      %5 = tile.select %2, %3, %4 : (tensor<3x3xi1>, tensor<i1>, tensor<i1>) -> tensor<3x3xi1>
      %6 = tile.contract mul, none, %c1, %5 {sink = #map0, srcs = [#map1]} : tensor<i1>, tensor<3x3xi1> -> tensor<3xi1>
      %7 = tile.cast %6 : (tensor<3xi1>) -> tensor<3xui8>
      layer.return %7 : tensor<3xui8>
    } {attrs = {keep_dims = 0 : i64}}
    %1 = tile.cast %0 : (tensor<3xui8>) -> tensor<3xf32>
    return %1 : tensor<3xf32>
  }
}
```
 which plaidml tensor `mul` and `sum` do not support `i1` computations well.
Cast input tensor to `FP32` can help it pass tests.