### PR TITLE
Fix negative reduction axes

### DIFF
--- a/plaidml/bridge/openvino/ops/reduce.cpp
+++ b/plaidml/bridge/openvino/ops/reduce.cpp
@@ -19,7 +19,7 @@ void registerReduceOps() {
   registerOp("ReduceLogicalAnd", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalAnd>(ctx.layer);
     I = edsl::cast(I, DType::FLOAT32);
     return edsl::make_tuple(op::all(I, edsl::make_tuple(axes), layer->get_keep_dims()));
@@ -28,7 +28,7 @@ void registerReduceOps() {
   registerOp("ReduceLogicalOr", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceLogicalOr>(ctx.layer);
     I = edsl::cast(I, DType::FLOAT32);
     return edsl::make_tuple(op::any(I, edsl::make_tuple(axes), layer->get_keep_dims()));
@@ -37,7 +37,7 @@ void registerReduceOps() {
   registerOp("ReduceMax", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMax>(ctx.layer);
     return edsl::make_tuple(op::max(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -45,7 +45,7 @@ void registerReduceOps() {
   registerOp("ReduceMean", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMean>(ctx.layer);
     return edsl::make_tuple(op::mean(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -53,7 +53,7 @@ void registerReduceOps() {
   registerOp("ReduceMin", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceMin>(ctx.layer);
     return edsl::make_tuple(op::min(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -61,7 +61,7 @@ void registerReduceOps() {
   registerOp("ReduceProd", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceProd>(ctx.layer);
     return edsl::make_tuple(op::prod(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -69,7 +69,7 @@ void registerReduceOps() {
   registerOp("ReduceSum", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset1::ReduceSum>(ctx.layer);
     return edsl::make_tuple(op::sum(I, edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -77,7 +77,7 @@ void registerReduceOps() {
   registerOp("ReduceL1", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL1>(ctx.layer);
     return edsl::make_tuple(op::sum(op::abs(I), edsl::make_tuple(axes), layer->get_keep_dims()));
   });
@@ -85,7 +85,7 @@ void registerReduceOps() {
   registerOp("ReduceL2", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 2);
     auto I = ctx.operands.at(0);
-    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
+    std::vector<int64_t> axes = cast_constant_operand<int64_t>(1, ctx.layer);
     auto* layer = ngraph::as_type<ngraph::opset4::ReduceL2>(ctx.layer);
     return edsl::make_tuple(edsl::sqrt(op::sum(I * I, edsl::make_tuple(axes), layer->get_keep_dims())));
   });

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/reduce_ops.cpp
@@ -182,14 +182,12 @@ INSTANTIATE_TEST_CASE_P(                 //
     params_InputShapes,                  //
     ReduceOpsLayerTest::getTestCaseName  //
 );
-/*
 INSTANTIATE_TEST_CASE_P(                 //
     Reduce_Axes,                         //
     ReduceOpsLayerTest,                  //
     params_Axes,                         //
     ReduceOpsLayerTest::getTestCaseName  //
 );
-*/
 INSTANTIATE_TEST_CASE_P(                 //
     Reduce_ReductionTypes,               //
     ReduceOpsLayerTest,                  //


### PR DESCRIPTION
The original one interplated axis as ngraph `AxisVector` which inherits from vector<size_t>, so that negetive axis will be casted and cause error. 
```cpp
    std::vector<size_t> axes = get_axis_vector_from_constant_operand(1, ctx.layer);
```
Directly use `int64_t` helps solve this problem.