### PR TITLE
Fix OneHot and *Cell Ops

### DIFF
--- a/plaidml/bridge/openvino/ops/gru_cell.cpp
+++ b/plaidml/bridge/openvino/ops/gru_cell.cpp
@@ -4,7 +4,6 @@
 
 #include <limits>
 
-#include "ngraph/opsets/opset.hpp"
 #include "ngraph/opsets/opset4.hpp"
 #include "plaidml/op/op.h"
 #include "plaidml_ops.hpp"

--- a/plaidml/bridge/openvino/ops/gru_cell.cpp
+++ b/plaidml/bridge/openvino/ops/gru_cell.cpp
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <limits>
-
 #include "ngraph/opsets/opset4.hpp"
 #include "plaidml/op/op.h"
 #include "plaidml_ops.hpp"
 #include "plaidml_util.hpp"
+#include <limits>
 
 using namespace plaidml;          // NOLINT[build/namespaces]
 using namespace InferenceEngine;  // NOLINT[build/namespaces]
@@ -61,7 +60,7 @@ void registerGruCell() {
       Th = op::dot(Xt, op::transpose(Wh)) + rt * (op::dot(Ht_1, op::transpose(Rh)) + Bhr) + Bhw;
     } else {
       auto Bh = op::slice(B).add_dim(2 * hidden_size, 3 * hidden_size);
-      Th = op::dot(Xt, op::transpose(Wh)) + op::dot(rt * Ht_1, op::transpose(Rh) + Bh);
+      Th = op::dot(Xt, op::transpose(Wh)) + op::dot(rt * Ht_1, op::transpose(Rh)) + Bh;
     }
     auto ht_tilde = clip_activation(activation_g, should_clip, clip, Th);
     auto Ht = (1 - zt) * ht_tilde + zt * Ht_1;

--- a/plaidml/bridge/openvino/ops/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/ops/lstm_cell.cpp
@@ -18,9 +18,9 @@ namespace PlaidMLPlugin {
 void registerLstmCell() {
   registerOp("LstmCell", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 6);
-    auto Xt = ctx.operands.at(0);    // input tensor
-    auto Ht_1 = ctx.operands.at(1);  // hidden state tensor
-    auto Ct_1 = ctx.operands.at(2);  // cell state tensor
+    auto xt = ctx.operands.at(0);    // input tensor
+    auto ht_1 = ctx.operands.at(1);  // hidden state tensor
+    auto ct_1 = ctx.operands.at(2);  // cell state tensor
     auto W = ctx.operands.at(3);     // weight tensor [4 * hidden_size, input_size]
     auto R = ctx.operands.at(4);     // recurrence weight tensor [4 * hidden_size, input_size]
     auto B = ctx.operands.at(5);     // bias tensor [4 * hidden_size]
@@ -40,7 +40,7 @@ void registerLstmCell() {
     auto clip = layer->get_clip();
     auto should_clip = (clip > 0.f) && (clip != std::numeric_limits<float>::infinity());
 
-    auto gates_output = op::dot(Xt, op::transpose(W)) + op::dot(Ht_1, op::transpose(R)) + op::unsqueeze(B, {0});
+    auto gates_output = op::dot(xt, op::transpose(W)) + op::dot(ht_1, op::transpose(R)) + op::unsqueeze(B, {0});
     auto hidden_indices = edsl::index({edsl::TensorDim(hidden_size)}, 0);
     edsl::Tensor ft = edsl::gather(gates_output, hidden_indices).axis(1);
     edsl::Tensor it = edsl::gather(gates_output, hidden_indices + hidden_size).axis(1);
@@ -51,10 +51,10 @@ void registerLstmCell() {
     ct = clip_activation(activation_g, should_clip, clip, ct);
     ot = clip_activation(activation_f, should_clip, clip, ot);
 
-    auto Ct = ft * Ct_1 + it * ct;
-    auto Ht = ot * clip_activation(activation_h, should_clip, clip, Ct);
+    auto Ct = ft * ct_1 + it * ct;
+    auto Ht = ot * clip_activation(activation_h, false, clip, Ct);
 
-    return edsl::make_tuple(Ct, Ht);
+    return edsl::make_tuple(Ht, Ct);
   });
 }
 

--- a/plaidml/bridge/openvino/ops/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/ops/rnn_cell.cpp
@@ -17,11 +17,11 @@ namespace PlaidMLPlugin {
 void registerRnnCell() {
   registerOp("RnnCell", [](const Context& ctx) {
     IE_ASSERT(ctx.operands.size() == 5);
-    auto Xt = ctx.operands.at(0);    // input tensor
-    auto Ht_1 = ctx.operands.at(1);  // hidden state tensor
-    auto Wi = ctx.operands.at(2);    // weight tensor [hidden_size, input_size]
-    auto Ri = ctx.operands.at(3);    // recurrence weight tensor [hidden_size, input_size]
-    auto Bi = ctx.operands.at(4);    // bias tensor [hidden_size]
+    auto xt = ctx.operands.at(0);    // input tensor
+    auto ht_1 = ctx.operands.at(1);  // hidden state tensor
+    auto W = ctx.operands.at(2);     // weight tensor [hidden_size, input_size]
+    auto R = ctx.operands.at(3);     // recurrence weight tensor [hidden_size, input_size]
+    auto B = ctx.operands.at(4);     // bias tensor [hidden_size]
 
     auto* layer = ngraph::as_type<ngraph::opset4::RNNCell>(ctx.layer);
 
@@ -35,10 +35,10 @@ void registerRnnCell() {
     auto clip = layer->get_clip();
     auto should_clip = (clip > 0.f) && (clip != std::numeric_limits<float>::infinity());
 
-    auto Ti = op::dot(Xt, op::transpose(Wi)) + op::dot(Ht_1, op::transpose(Ri)) + Bi;
-    auto Ht = clip_activation(activation, should_clip, clip, Ti);
+    auto ht = op::dot(xt, op::transpose(W)) + op::dot(ht_1, op::transpose(R)) + B;
+    ht = clip_activation(activation, should_clip, clip, ht);
 
-    return edsl::make_tuple(Ht);
+    return edsl::make_tuple(ht);
   });
 }
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -11,8 +11,8 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    // true will decompose rnn cell to component ops and
-    // skip plaidml plugin implementation, only set to false here
+    // true will decompose GRUCell to component ops and skip plaidml GRUCell implementation
+    true,
     false,
 };
 std::vector<size_t> batch{5};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -11,8 +11,9 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    // false,
-    true,
+    // true will decompose rnn cell to component ops and
+    // skip plaidml plugin implementation, only set to false here
+    false,
 };
 std::vector<size_t> batch{5};
 std::vector<size_t> hidden_size{
@@ -24,8 +25,10 @@ std::vector<size_t> input_size{
     30,
 };
 std::vector<std::vector<std::string>> activations = {
-    {"relu", "tanh"}, {"tanh", "sigmoid"}, {"sigmoid", "tanh"},
-    // {"tanh", "relu"},
+    {"relu", "tanh"},
+    {"tanh", "sigmoid"},
+    {"sigmoid", "tanh"},
+    {"tanh", "relu"},
 };
 std::vector<float> clips = {
     0.0f,
@@ -55,7 +58,7 @@ INSTANTIATE_TEST_CASE_P(GRUCellCommon, GRUCellTest,
 
 INSTANTIATE_TEST_CASE_P(smoke, GRUCellTest,
                         ::testing::Combine(                                                 //
-                            ::testing::Values(true),                                        //
+                            ::testing::Values(false),                                       //
                             ::testing::Values(3),                                           //
                             ::testing::Values(32),                                          //
                             ::testing::Values(16),                                          //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -21,9 +21,11 @@ std::vector<size_t> hidden_size{
     10,
 };
 std::vector<size_t> input_size{
-    1,
+    3,
     30,
 };
+// When set `relu` as Gate gate activation and forbid clip, it
+// potentially will get a big error.
 std::vector<std::vector<std::string>> activations = {
     {"relu", "tanh"},
     {"tanh", "sigmoid"},

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -11,8 +11,9 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    true,
-    // false,
+    // true will decompose lstm cell to component ops and
+    // skip plaidml plugin implementation, only set to false here
+    false,
 };
 std::vector<size_t> batch{5};
 std::vector<size_t> hidden_size{1, 10};
@@ -59,7 +60,7 @@ INSTANTIATE_TEST_CASE_P(LSTMCellF16, LSTMCellTest,
 
 INSTANTIATE_TEST_CASE_P(smoke, LSTMCellTest,
                         ::testing::Combine(                                                            //
-                            ::testing::Values(true),                                                   //
+                            ::testing::Values(false),                                                  //
                             ::testing::Values(3),                                                      //
                             ::testing::Values(64),                                                     //
                             ::testing::Values(32),                                                     //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -11,8 +11,8 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    // true will decompose lstm cell to component ops and
-    // skip plaidml plugin implementation, only set to false here
+    // true will decompose LSTMCell to component ops and skip plaidml LSTMCell implementation
+    true,
     false,
 };
 std::vector<size_t> batch{5};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/one_hot.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/one_hot.cpp
@@ -104,8 +104,8 @@ const std::vector<int64_t> argDepth_T = {1};
 const std::vector<ngraph::element::Type> argSetType_T = {
     ngraph::element::i8,
     ngraph::element::u8,
-    ngraph::element::bf16,
     ngraph::element::f32,
+    // ngraph::element::bf16,  // Currently not supported
 };
 const std::vector<float> argOnValue_T = {1};
 const std::vector<float> argOffValue_T = {1};
@@ -126,10 +126,10 @@ const auto oneHotParams_T = testing::Combine(         //
     testing::Values(CommonTestUtils::DEVICE_PLAIDML)  //
 );
 
-// INSTANTIATE_TEST_CASE_P(             //
-//    smoke_OneHotArgType,              //
-//    OneHotLayerTest,                  //
-//    oneHotParams_T,                   //
-//    OneHotLayerTest::getTestCaseName  //
-//);
+INSTANTIATE_TEST_CASE_P(              //
+    smoke_OneHotArgType,              //
+    OneHotLayerTest,                  //
+    oneHotParams_T,                   //
+    OneHotLayerTest::getTestCaseName  //
+);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -11,8 +11,9 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    true,
-    // false,
+    // true will decompose rnn cell to component ops and
+    // skip plaidml plugin implementation, only set to false here
+    false,
 };
 std::vector<size_t> batch{1, 5};
 std::vector<size_t> hidden_size{1, 10};

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/rnn_cell.cpp
@@ -11,8 +11,8 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 std::vector<bool> should_decompose{
-    // true will decompose rnn cell to component ops and
-    // skip plaidml plugin implementation, only set to false here
+    // true will decompose RNNCell to component ops and skip plaidml RNNCell implementation
+    true,
     false,
 };
 std::vector<size_t> batch{1, 5};


### PR DESCRIPTION
Disable decompose for RNN, GRU and LSTM Cell Ops to force compare openvino reference with plaidml plugin implementations.

After above changes
* RNN can pass all tests
* GRU have the same tests failure as before - (precision is fp16 and activations are tanh & relu)
* LSTM can pass all tests

Done: 
- [x] Fix above failed tests
- [x] Use tensor MatMul first and then gather way to replace old implementation to make implementation more simple.

For the precision issue, 
it happens under certain parameters group: no clip, FP16, use `relu` as `Gate gate` activation.
When got some special case large tensor input, it will large value (10-100) Intermediate tensor which will enlarge the error. 

So there are some strategy to avoid this issue in test case settings:
* Forbid `relu` as `Gate` gate activation
* Forbid `FP16` precision
* Use other tensor input shape to avoid this error-triggered input values 