### PR TITLE
Add OV bridge missing tests

### DIFF
--- a/plaidml/bridge/openvino/ops/broadcast.cpp
+++ b/plaidml/bridge/openvino/ops/broadcast.cpp
@@ -34,7 +34,7 @@ void registerBroadcast() {
         if (ctx.operands.size() != 3) {
           THROW_IE_EXCEPTION << "An axes_mapping must be passed to broadcast when using explicit mode";
         }
-        axes_mapping = get_axis_vector_from_constant_operand(2, layer);
+        axes_mapping = cast_constant_operand<size_t>(2, layer);
         break;
       case ngraph::op::AutoBroadcastType::NUMPY: {
         auto excess_rank = target_shape.size() - I.rank();

--- a/plaidml/bridge/openvino/ops/normalize_l2.cpp
+++ b/plaidml/bridge/openvino/ops/normalize_l2.cpp
@@ -25,8 +25,8 @@ void registerNormalizeL2() {
     auto eps_mode = layer->get_eps_mode();
 
     if (axes.empty()) {
-      auto N = I + eps;
-      return edsl::make_tuple(I / N);
+      axes = std::vector<size_t>(I.compute_shape().sizes().size());
+      std::iota(axes.begin(), axes.end(), 0);
     }
 
     plaidml::op::EpsMode edsl_eps_mode;

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
@@ -1,0 +1,173 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/broadcast.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> inputPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+    InferenceEngine::Precision::BOOL,
+};
+
+// NUMPY MODE
+
+std::vector<std::vector<size_t>> inShapesNumpy = {
+    {3, 1},
+    {1, 4, 1},
+};
+
+std::vector<std::vector<size_t>> targetShapesNumpy = {
+    {2, 3, 6},
+    {1, 4, 4},
+};
+
+const auto numpyBroadcastParams1 = ::testing::Combine(    //
+    ::testing::Values(targetShapesNumpy[0]),              //
+    ::testing::Values(ngraph::AxisSet{}),                 // not used in numpy mode
+    ::testing::Values(ngraph::op::BroadcastType::NUMPY),  //
+    ::testing::Values(inShapesNumpy[0]),                  //
+    ::testing::ValuesIn(inputPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+);
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestNumpyBroadcast1,           //
+    BroadcastLayerTest,                  //
+    numpyBroadcastParams1,               //
+    BroadcastLayerTest::getTestCaseName  //
+);
+
+const auto numpyBroadcastParams2 = ::testing::Combine(    //
+    ::testing::Values(targetShapesNumpy[1]),              //
+    ::testing::Values(ngraph::AxisSet{}),                 // not used in numpy mode
+    ::testing::Values(ngraph::op::BroadcastType::NUMPY),  //
+    ::testing::Values(inShapesNumpy[1]),                  //
+    ::testing::ValuesIn(inputPrecisions),                 //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)    //
+);
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestNumpyBroadcast2,           //
+    BroadcastLayerTest,                  //
+    numpyBroadcastParams2,               //
+    BroadcastLayerTest::getTestCaseName  //
+);
+
+// BIDIRECTIONAL MODE
+
+std::vector<std::vector<size_t>> inShapesBidi = {
+    {4, 1},
+    {1, 4, 1},
+    {4, 1, 1},
+};
+
+std::vector<std::vector<size_t>> targetShapesBidi = {
+    {2, 1, 4},
+    {1, 4, 4},
+    {1, 1, 2, 2},
+};
+
+const auto bidirectionalBroadcastParams1 = ::testing::Combine(    //
+    ::testing::Values(targetShapesBidi[0]),                       //
+    ::testing::Values(ngraph::AxisSet{}),                         // not used in bidirectional mode
+    ::testing::Values(ngraph::op::BroadcastType::BIDIRECTIONAL),  //
+    ::testing::Values(inShapesBidi[0]),                           //
+    ::testing::ValuesIn(inputPrecisions),                         //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)            //
+);
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestBidirectionalBroadcast1,   //
+    BroadcastLayerTest,                  //
+    bidirectionalBroadcastParams1,       //
+    BroadcastLayerTest::getTestCaseName  //
+);
+
+const auto bidirectionalBroadcastParams2 =
+    ::testing::Combine(::testing::Values(targetShapesBidi[1]),                       //
+                       ::testing::Values(ngraph::AxisSet{}),                         // not used in bidirectional mode
+                       ::testing::Values(ngraph::op::BroadcastType::BIDIRECTIONAL),  //
+                       ::testing::Values(inShapesBidi[1]),                           //
+                       ::testing::ValuesIn(inputPrecisions),                         //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)            //
+    );
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestBidirectionalBroadcast2,   //
+    BroadcastLayerTest,                  //
+    bidirectionalBroadcastParams2,       //
+    BroadcastLayerTest::getTestCaseName  //
+);
+
+const auto bidirectionalBroadcastParams3 = ::testing::Combine(    //
+    ::testing::Values(targetShapesBidi[2]),                       //
+    ::testing::Values(ngraph::AxisSet{}),                         // not used in bidirectional mode
+    ::testing::Values(ngraph::op::BroadcastType::BIDIRECTIONAL),  //
+    ::testing::Values(inShapesBidi[2]),                           //
+    ::testing::ValuesIn(inputPrecisions),                         //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)            //
+);
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestBidirectionalBroadcast3,   //
+    BroadcastLayerTest,                  //
+    bidirectionalBroadcastParams3,       //
+    BroadcastLayerTest::getTestCaseName  //
+);
+
+// EXPLICIT MODE
+
+std::vector<std::vector<size_t>> inShapesExplicit = {
+    {3, 1},
+    {2, 4},
+};
+
+std::vector<std::vector<size_t>> targetShapesExplicit = {
+    {2, 3, 1},
+    {2, 3, 4},
+};
+
+std::vector<ngraph::AxisSet> axes = {
+    {1, 2},
+    {0, 2},
+};
+
+const auto explicitBroadcastParams1 = ::testing::Combine(    //
+    ::testing::Values(targetShapesExplicit[0]),              //
+    ::testing::Values(axes[0]),                              //
+    ::testing::Values(ngraph::op::BroadcastType::EXPLICIT),  //
+    ::testing::Values(inShapesExplicit[0]),                  //
+    ::testing::ValuesIn(inputPrecisions),                    //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)       //
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_TestExplicitBroadcast1,        //
+                        BroadcastLayerTest,                  //
+                        explicitBroadcastParams1,            //
+                        BroadcastLayerTest::getTestCaseName  //
+);
+
+const auto explicitBroadcastParams2 = ::testing::Combine(    //
+    ::testing::Values(targetShapesExplicit[1]),              //
+    ::testing::Values(axes[1]),                              //
+    ::testing::Values(ngraph::op::BroadcastType::EXPLICIT),  //
+    ::testing::Values(inShapesExplicit[1]),                  //
+    ::testing::ValuesIn(inputPrecisions),                    //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)       //
+);
+
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestExplicitBroadcast2,        //
+    BroadcastLayerTest,                  //
+    explicitBroadcastParams2,            //
+    BroadcastLayerTest::getTestCaseName  //
+);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
@@ -91,14 +91,14 @@ INSTANTIATE_TEST_CASE_P(                 //
     BroadcastLayerTest::getTestCaseName  //
 );
 
-const auto bidirectionalBroadcastParams2 =
-    ::testing::Combine(::testing::Values(targetShapesBidi[1]),                       //
-                       ::testing::Values(ngraph::AxisSet{}),                         // not used in bidirectional mode
-                       ::testing::Values(ngraph::op::BroadcastType::BIDIRECTIONAL),  //
-                       ::testing::Values(inShapesBidi[1]),                           //
-                       ::testing::ValuesIn(inputPrecisions),                         //
-                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)            //
-    );
+const auto bidirectionalBroadcastParams2 = ::testing::Combine(    //
+    ::testing::Values(targetShapesBidi[1]),                       //
+    ::testing::Values(ngraph::AxisSet{}),                         // not used in bidirectional mode
+    ::testing::Values(ngraph::op::BroadcastType::BIDIRECTIONAL),  //
+    ::testing::Values(inShapesBidi[1]),                           //
+    ::testing::ValuesIn(inputPrecisions),                         //
+    ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)            //
+);
 
 INSTANTIATE_TEST_CASE_P(                 //
     smoke_TestBidirectionalBroadcast2,   //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/broadcast.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -149,10 +149,11 @@ const auto explicitBroadcastParams1 = ::testing::Combine(    //
     ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)       //
 );
 
-INSTANTIATE_TEST_CASE_P(smoke_TestExplicitBroadcast1,        //
-                        BroadcastLayerTest,                  //
-                        explicitBroadcastParams1,            //
-                        BroadcastLayerTest::getTestCaseName  //
+INSTANTIATE_TEST_CASE_P(                 //
+    smoke_TestExplicitBroadcast1,        //
+    BroadcastLayerTest,                  //
+    explicitBroadcastParams1,            //
+    BroadcastLayerTest::getTestCaseName  //
 );
 
 const auto explicitBroadcastParams2 = ::testing::Combine(    //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -17,12 +17,29 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
 };
 
 const std::vector<std::vector<size_t>> inputShapes = {
-    {1, 1},           {2, 6},           {1, 1, 1},         {2, 6, 13},       {1, 1, 1, 1},
-    {3, 10, 5, 6},    {2, 8, 5, 18},    {2, 16, 3, 18},    {3, 49, 5, 6},    {1, 1, 1, 1, 1},
-    {3, 10, 2, 5, 6}, {2, 8, 1, 5, 18}, {2, 16, 4, 3, 18}, {3, 49, 7, 5, 6},
+    {1, 1},             //
+    {2, 6},             //
+    {1, 1, 1},          //
+    {2, 6, 13},         //
+    {1, 1, 1, 1},       //
+    {3, 10, 5, 6},      //
+    {2, 8, 5, 18},      //
+    {2, 16, 3, 18},     //
+    {3, 49, 5, 6},      //
+    {1, 1, 1, 1, 1},    //
+    {3, 10, 2, 5, 6},   //
+    {2, 8, 1, 5, 18},   //
+    {2, 16, 4, 3, 18},  //
+    {3, 49, 7, 5, 6},   //
 };
-const std::vector<std::vector<size_t>> constShapes = {{1}};
-const std::vector<size_t> levels = {16, 255, 256};
+const std::vector<std::vector<size_t>> constShapes = {
+    {1},
+};
+const std::vector<size_t> levels = {
+    16,
+    255,
+    256,
+};
 
 const std::pair<std::string, std::map<std::string, std::string>> config = {};
 const std::vector<float> fqArgs = {};
@@ -48,9 +65,16 @@ INSTANTIATE_TEST_CASE_P(smoke_FakeQuantize, FakeQuantizeLayerTest,              
                             ::testing::Values(config)),                                  //
                         FakeQuantizeLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t>> inputShapesPerChannel = {{11, 10, 22, 19}, {11, 10, 5, 6}};
-const std::vector<std::vector<size_t>> constShapesPerChannelAxis0 = {{11, 1, 1, 1}};
-const std::vector<std::vector<size_t>> constShapesPerChannelAxis1 = {{1, 10, 1, 1}};
+const std::vector<std::vector<size_t>> inputShapesPerChannel = {
+    {11, 10, 22, 19},
+    {11, 10, 5, 6},
+};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis0 = {
+    {11, 1, 1, 1},
+};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis1 = {
+    {1, 10, 1, 1},
+};
 
 const auto fqParamsPerChannelAxis0 = ::testing::Combine(  //
     ::testing::ValuesIn(levels),                          //
@@ -92,8 +116,14 @@ INSTANTIATE_TEST_CASE_P(smoke_FakeQuantizePerChannelAxis1, FakeQuantizeLayerTest
                             ::testing::Values(config)),                                  //
                         FakeQuantizeLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t>> inputShapesPerChannel2D = {{1, 10}};
-const std::vector<std::vector<size_t>> constShapesPerChannel2D = {{10}, {1, 10}, {1}};
+const std::vector<std::vector<size_t>> inputShapesPerChannel2D = {
+    {1, 10},
+};
+const std::vector<std::vector<size_t>> constShapesPerChannel2D = {
+    {10},
+    {1, 10},
+    {1},
+};
 const auto fqParamsPerChannel2D = ::testing::Combine(  //
     ::testing::ValuesIn(levels),                       //
     ::testing::ValuesIn(constShapesPerChannel2D),      //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -1,0 +1,105 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/fake_quantize.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+const std::vector<std::vector<size_t>> inputShapes = {
+    {1, 1},           {2, 6},           {1, 1, 1},         {2, 6, 13},       {1, 1, 1, 1},
+    {3, 10, 5, 6},    {2, 8, 5, 18},    {2, 16, 3, 18},    {3, 49, 5, 6},    {1, 1, 1, 1, 1},
+    {3, 10, 2, 5, 6}, {2, 8, 1, 5, 18}, {2, 16, 4, 3, 18}, {3, 49, 7, 5, 6},
+};
+const std::vector<std::vector<size_t>> constShapes = {{1}};
+const std::vector<size_t> levels = {
+    16,
+    255,
+    256,
+};
+
+const std::pair<std::string, std::map<std::string, std::string>> config = {};
+const std::vector<float> fqArgs = {};
+const std::vector<float> inputParams = {};
+
+const auto fqParams = ::testing::Combine(  //
+    ::testing::ValuesIn(levels),           //
+    ::testing::ValuesIn(constShapes),      //
+    ::testing::Values(fqArgs),             //
+    ::testing::Values(inputParams)         //
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantize, FakeQuantizeLayerTest,                       //
+                        ::testing::Combine(                                              //
+                            fqParams,                                                    //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::ValuesIn(inputShapes),                            //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+                            ::testing::Values(config)),                                  //
+                        FakeQuantizeLayerTest::getTestCaseName);                         //
+
+const std::vector<std::vector<size_t>> inputShapesPerChannel = {
+    {11, 10, 22, 19},
+    {11, 10, 5, 6},
+};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis0 = {
+    {11, 1, 1, 1},
+};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis1 = {
+    {1, 10, 1, 1},
+};
+
+const auto fqParamsPerChannelAxis0 = ::testing::Combine(  //
+    ::testing::ValuesIn(levels),                          //
+    ::testing::ValuesIn(constShapesPerChannelAxis0),      //
+    ::testing::Values(fqArgs),                            //
+    ::testing::Values(inputParams)                        //
+);
+
+const auto fqParamsPerChannelAxis1 = ::testing::Combine(  //
+    ::testing::ValuesIn(levels),                          //
+    ::testing::ValuesIn(constShapesPerChannelAxis1),      //
+    ::testing::Values(fqArgs),                            //
+    ::testing::Values(inputParams)                        //
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantizePerChannelAxis0, FakeQuantizeLayerTest,        //
+                        ::testing::Combine(                                              //
+                            fqParamsPerChannelAxis0,                                     //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::ValuesIn(inputShapesPerChannel),                  //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+                            ::testing::Values(config)),                                  //
+                        FakeQuantizeLayerTest::getTestCaseName);                         //
+
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantizePerChannelAxis1, FakeQuantizeLayerTest,        //
+                        ::testing::Combine(                                              //
+                            fqParamsPerChannelAxis1,                                     //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::ValuesIn(inputShapesPerChannel),                  //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+                            ::testing::Values(config)),                                  //
+                        FakeQuantizeLayerTest::getTestCaseName);                         //
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,11 +22,7 @@ const std::vector<std::vector<size_t>> inputShapes = {
     {3, 10, 2, 5, 6}, {2, 8, 1, 5, 18}, {2, 16, 4, 3, 18}, {3, 49, 7, 5, 6},
 };
 const std::vector<std::vector<size_t>> constShapes = {{1}};
-const std::vector<size_t> levels = {
-    16,
-    255,
-    256,
-};
+const std::vector<size_t> levels = {16, 255, 256};
 
 const std::pair<std::string, std::map<std::string, std::string>> config = {};
 const std::vector<float> fqArgs = {};
@@ -50,18 +46,11 @@ INSTANTIATE_TEST_CASE_P(smoke_FakeQuantize, FakeQuantizeLayerTest,              
                             ::testing::ValuesIn(inputShapes),                            //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
                             ::testing::Values(config)),                                  //
-                        FakeQuantizeLayerTest::getTestCaseName);                         //
+                        FakeQuantizeLayerTest::getTestCaseName);
 
-const std::vector<std::vector<size_t>> inputShapesPerChannel = {
-    {11, 10, 22, 19},
-    {11, 10, 5, 6},
-};
-const std::vector<std::vector<size_t>> constShapesPerChannelAxis0 = {
-    {11, 1, 1, 1},
-};
-const std::vector<std::vector<size_t>> constShapesPerChannelAxis1 = {
-    {1, 10, 1, 1},
-};
+const std::vector<std::vector<size_t>> inputShapesPerChannel = {{11, 10, 22, 19}, {11, 10, 5, 6}};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis0 = {{11, 1, 1, 1}};
+const std::vector<std::vector<size_t>> constShapesPerChannelAxis1 = {{1, 10, 1, 1}};
 
 const auto fqParamsPerChannelAxis0 = ::testing::Combine(  //
     ::testing::ValuesIn(levels),                          //
@@ -101,5 +90,27 @@ INSTANTIATE_TEST_CASE_P(smoke_FakeQuantizePerChannelAxis1, FakeQuantizeLayerTest
                             ::testing::ValuesIn(inputShapesPerChannel),                  //
                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
                             ::testing::Values(config)),                                  //
-                        FakeQuantizeLayerTest::getTestCaseName);                         //
+                        FakeQuantizeLayerTest::getTestCaseName);
+
+const std::vector<std::vector<size_t>> inputShapesPerChannel2D = {{1, 10}};
+const std::vector<std::vector<size_t>> constShapesPerChannel2D = {{10}, {1, 10}, {1}};
+const auto fqParamsPerChannel2D = ::testing::Combine(  //
+    ::testing::ValuesIn(levels),                       //
+    ::testing::ValuesIn(constShapesPerChannel2D),      //
+    ::testing::Values(fqArgs),                         //
+    ::testing::Values(inputParams)                     //
+);
+
+INSTANTIATE_TEST_CASE_P(smoke_FakeQuantizePerChannel2D, FakeQuantizeLayerTest,
+                        ::testing::Combine(                                              //
+                            fqParamsPerChannel2D,                                        //
+                            ::testing::ValuesIn(netPrecisions),                          //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::Values(InferenceEngine::Layout::ANY),             //
+                            ::testing::ValuesIn(inputShapesPerChannel2D),                //
+                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML),          //
+                            ::testing::Values(config)),                                  //
+                        FakeQuantizeLayerTest::getTestCaseName);
 }  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -13,7 +13,7 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
+    // InferenceEngine::Precision::FP16,
 };
 
 const std::vector<std::vector<size_t>> inputShapes = {

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/normalize_l2.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/normalize_l2.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/normalize_l2.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/normalize_l2.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/normalize_l2.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::FP16,
+};
+
+const std::vector<std::vector<int64_t>> axes = {
+    {},
+    {1},
+};
+const std::vector<float> eps = {
+    1e-7f,
+    1e-6f,
+    1e-5f,
+    1e-4f,
+};
+
+const std::vector<ngraph::op::EpsMode> epsMode = {
+    ngraph::op::EpsMode::ADD,
+    ngraph::op::EpsMode::MAX,
+};
+
+const auto normL2params = testing::Combine(                                           //
+    testing::ValuesIn(axes),                                                          //
+    testing::ValuesIn(eps),                                                           //
+    testing::ValuesIn(epsMode),                                                       //
+    testing::ValuesIn(std::vector<std::vector<size_t>>({{1, 3, 10, 5}, {1, 5, 3}})),  //
+    testing::ValuesIn(netPrecisions),                                                 //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)                                  //
+);
+
+INSTANTIATE_TEST_CASE_P(                   //
+    NormalizeL2,                           //
+    NormalizeL2LayerTest,                  //
+    normL2params,                          //
+    NormalizeL2LayerTest::getTestCaseName  //
+);
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
@@ -19,7 +19,12 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::U8,    //
 };
 
-const std::vector<float> argPadValue = {0.f, 1.f, -1.f, 2.5f};
+const std::vector<float> argPadValue = {
+    0.f,
+    1.f,
+    -1.f,
+    2.5f,
+};
 
 const std::vector<ngraph::helpers::PadMode> padMode = {
     ngraph::helpers::PadMode::CONSTANT,
@@ -28,8 +33,16 @@ const std::vector<ngraph::helpers::PadMode> padMode = {
     //    ngraph::helpers::PadMode::SYMMETRIC,
 };
 
-const std::vector<std::vector<int64_t>> padsBegin1D = {{0}, {1}, {2}};
-const std::vector<std::vector<int64_t>> padsEnd1D = {{0}, {1}, {2}};
+const std::vector<std::vector<int64_t>> padsBegin1D = {
+    {0},
+    {1},
+    {2},
+};
+const std::vector<std::vector<int64_t>> padsEnd1D = {
+    {0},
+    {1},
+    {2},
+};
 
 const auto pad1DConstparams = testing::Combine(                //
     testing::ValuesIn(padsBegin1D),                            //
@@ -70,8 +83,18 @@ INSTANTIATE_TEST_CASE_P(           //
     PadLayerTest::getTestCaseName  //
 );
 
-const std::vector<std::vector<int64_t>> padsBegin2D = {{0, 0}, {1, 1}, {2, 0}, {0, 3}};
-const std::vector<std::vector<int64_t>> padsEnd2D = {{0, 0}, {1, 1}, {0, 1}, {3, 2}};
+const std::vector<std::vector<int64_t>> padsBegin2D = {
+    {0, 0},
+    {1, 1},
+    {2, 0},
+    {0, 3},
+};
+const std::vector<std::vector<int64_t>> padsEnd2D = {
+    {0, 0},
+    {1, 1},
+    {0, 1},
+    {3, 2},
+};
 
 const auto pad2DConstparams = testing::Combine(                //
     testing::ValuesIn(padsBegin2D),                            //
@@ -113,10 +136,22 @@ INSTANTIATE_TEST_CASE_P(           //
     PadLayerTest::getTestCaseName  //
 );
 
-const std::vector<std::vector<int64_t>> padsBegin4D = {{0, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 0, 1},
-                                                       {0, 0, 1, 1}, {2, 0, 0, 0}, {0, 3, 0, 1}};
-const std::vector<std::vector<int64_t>> padsEnd4D = {{0, 0, 0, 0}, {0, 3, 0, 0}, {1, 0, 0, 0},
-                                                     {0, 0, 0, 2}, {1, 3, 0, 0}, {0, 3, 0, 1}};
+const std::vector<std::vector<int64_t>> padsBegin4D = {
+    {0, 0, 0, 0},  //
+    {0, 3, 0, 0},  //
+    {0, 0, 0, 1},  //
+    {0, 0, 1, 1},  //
+    {2, 0, 0, 0},  //
+    {0, 3, 0, 1},  //
+};
+const std::vector<std::vector<int64_t>> padsEnd4D = {
+    {0, 0, 0, 0},  //
+    {0, 3, 0, 0},  //
+    {1, 0, 0, 0},  //
+    {0, 0, 0, 2},  //
+    {1, 3, 0, 0},  //
+    {0, 3, 0, 1},  //
+};
 
 const auto pad4DConstparams = testing::Combine(                //
     testing::ValuesIn(padsBegin4D),                            //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
@@ -1,0 +1,134 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/pad.hpp"
+
+using namespace LayerTestsDefinitions;
+
+namespace {
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,  //
+    InferenceEngine::Precision::I32,   //
+    InferenceEngine::Precision::FP16,  //
+    InferenceEngine::Precision::I16,   //
+    InferenceEngine::Precision::U16,   //
+    InferenceEngine::Precision::I8,    //
+    InferenceEngine::Precision::U8,    //
+};
+
+const std::vector<std::vector<int64_t>> padsBegin2D = {
+    {0, 0},
+    {1, 1},
+    {2, 0},
+    {0, 3},
+};
+const std::vector<std::vector<int64_t>> padsEnd2D = {
+    {0, 0},
+    {1, 1},
+    {0, 1},
+    {3, 2},
+};
+const std::vector<float> argPadValue = {
+    0.f,
+    1.f,
+    -1.f,
+    2.5f,
+};
+
+const std::vector<ngraph::helpers::PadMode> padMode = {
+    ngraph::helpers::PadMode::EDGE,
+    ngraph::helpers::PadMode::REFLECT,
+    ngraph::helpers::PadMode::SYMMETRIC,
+};
+
+const auto pad2DConstparams = testing::Combine(                //
+    testing::ValuesIn(padsBegin2D),                            //
+    testing::ValuesIn(padsEnd2D),                              //
+    testing::ValuesIn(argPadValue),                            //
+    testing::Values(ngraph::helpers::PadMode::CONSTANT),       //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{13, 5}),               //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)           //
+);
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad2DConst,              //
+    PadLayerTest,                  //
+    pad2DConstparams,              //
+    PadLayerTest::getTestCaseName  //
+);
+
+const auto pad2Dparams = testing::Combine(                     //
+    testing::ValuesIn(padsBegin2D),                            //
+    testing::ValuesIn(padsEnd2D),                              //
+    testing::Values(0),                                        //
+    testing::ValuesIn(padMode),                                //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{13, 5}),               //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)           //
+);
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad2D,                   //
+    PadLayerTest,                  //
+    pad2Dparams,                   //
+    PadLayerTest::getTestCaseName  //
+);
+
+const std::vector<std::vector<int64_t>> padsBegin4D = {
+    {0, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 1}, {2, 0, 0, 0}, {0, 3, 0, 1},
+};
+const std::vector<std::vector<int64_t>> padsEnd4D = {
+    {0, 0, 0, 0}, {0, 3, 0, 0}, {1, 0, 0, 0}, {0, 0, 0, 2}, {1, 3, 0, 0}, {0, 3, 0, 1},
+};
+
+const auto pad4DConstparams = testing::Combine(                //
+    testing::ValuesIn(padsBegin4D),                            //
+    testing::ValuesIn(padsEnd4D),                              //
+    testing::ValuesIn(argPadValue),                            //
+    testing::Values(ngraph::helpers::PadMode::CONSTANT),       //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{3, 5, 10, 11}),        //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)           //
+);
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad4DConst,              //
+    PadLayerTest,                  //
+    pad4DConstparams,              //
+    PadLayerTest::getTestCaseName  //
+);
+
+const auto pad4Dparams = testing::Combine(                     //
+    testing::ValuesIn(padsBegin4D),                            //
+    testing::ValuesIn(padsEnd4D),                              //
+    testing::Values(0),                                        //
+    testing::ValuesIn(padMode),                                //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{3, 5, 10, 11}),        //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)           //
+);
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad4D,                   //
+    PadLayerTest,                  //
+    pad4Dparams,                   //
+    PadLayerTest::getTestCaseName  //
+);
+
+}  // namespace

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
@@ -38,10 +38,12 @@ const std::vector<float> argPadValue = {
     2.5f,
 };
 
+// Currently only CONSTANT pad mode is supported
 const std::vector<ngraph::helpers::PadMode> padMode = {
-    ngraph::helpers::PadMode::EDGE,
-    ngraph::helpers::PadMode::REFLECT,
-    ngraph::helpers::PadMode::SYMMETRIC,
+    ngraph::helpers::PadMode::CONSTANT,
+    //    ngraph::helpers::PadMode::EDGE,
+    //    ngraph::helpers::PadMode::REFLECT,
+    //    ngraph::helpers::PadMode::SYMMETRIC,
 };
 
 const auto pad2DConstparams = testing::Combine(                //

--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/pad.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Intel Corporation
+// Copyright (C) 2018-2021 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -19,32 +19,59 @@ const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::U8,    //
 };
 
-const std::vector<std::vector<int64_t>> padsBegin2D = {
-    {0, 0},
-    {1, 1},
-    {2, 0},
-    {0, 3},
-};
-const std::vector<std::vector<int64_t>> padsEnd2D = {
-    {0, 0},
-    {1, 1},
-    {0, 1},
-    {3, 2},
-};
-const std::vector<float> argPadValue = {
-    0.f,
-    1.f,
-    -1.f,
-    2.5f,
-};
+const std::vector<float> argPadValue = {0.f, 1.f, -1.f, 2.5f};
 
-// Currently only CONSTANT pad mode is supported
 const std::vector<ngraph::helpers::PadMode> padMode = {
     ngraph::helpers::PadMode::CONSTANT,
     //    ngraph::helpers::PadMode::EDGE,
     //    ngraph::helpers::PadMode::REFLECT,
     //    ngraph::helpers::PadMode::SYMMETRIC,
 };
+
+const std::vector<std::vector<int64_t>> padsBegin1D = {{0}, {1}, {2}};
+const std::vector<std::vector<int64_t>> padsEnd1D = {{0}, {1}, {2}};
+
+const auto pad1DConstparams = testing::Combine(                //
+    testing::ValuesIn(padsBegin1D),                            //
+    testing::ValuesIn(padsEnd1D),                              //
+    testing::ValuesIn(argPadValue),                            //
+    testing::Values(ngraph::helpers::PadMode::CONSTANT),       //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{5}),                   //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML));
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad1DConst,              //
+    PadLayerTest,                  //
+    pad1DConstparams,              //
+    PadLayerTest::getTestCaseName  //
+);
+
+const auto pad1Dparams = testing::Combine(                     //
+    testing::ValuesIn(padsBegin1D),                            //
+    testing::ValuesIn(padsEnd1D),                              //
+    testing::Values(0),                                        //
+    testing::ValuesIn(padMode),                                //
+    testing::ValuesIn(netPrecisions),                          //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Precision::UNSPECIFIED),  //
+    testing::Values(InferenceEngine::Layout::ANY),             //
+    testing::Values(std::vector<size_t>{5}),                   //
+    testing::Values(CommonTestUtils::DEVICE_PLAIDML)           //
+);
+
+INSTANTIATE_TEST_CASE_P(           //
+    smoke_Pad1D,                   //
+    PadLayerTest,                  //
+    pad1Dparams,                   //
+    PadLayerTest::getTestCaseName  //
+);
+
+const std::vector<std::vector<int64_t>> padsBegin2D = {{0, 0}, {1, 1}, {2, 0}, {0, 3}};
+const std::vector<std::vector<int64_t>> padsEnd2D = {{0, 0}, {1, 1}, {0, 1}, {3, 2}};
 
 const auto pad2DConstparams = testing::Combine(                //
     testing::ValuesIn(padsBegin2D),                            //
@@ -86,12 +113,10 @@ INSTANTIATE_TEST_CASE_P(           //
     PadLayerTest::getTestCaseName  //
 );
 
-const std::vector<std::vector<int64_t>> padsBegin4D = {
-    {0, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 0, 1}, {0, 0, 1, 1}, {2, 0, 0, 0}, {0, 3, 0, 1},
-};
-const std::vector<std::vector<int64_t>> padsEnd4D = {
-    {0, 0, 0, 0}, {0, 3, 0, 0}, {1, 0, 0, 0}, {0, 0, 0, 2}, {1, 3, 0, 0}, {0, 3, 0, 1},
-};
+const std::vector<std::vector<int64_t>> padsBegin4D = {{0, 0, 0, 0}, {0, 3, 0, 0}, {0, 0, 0, 1},
+                                                       {0, 0, 1, 1}, {2, 0, 0, 0}, {0, 3, 0, 1}};
+const std::vector<std::vector<int64_t>> padsEnd4D = {{0, 0, 0, 0}, {0, 3, 0, 0}, {1, 0, 0, 0},
+                                                     {0, 0, 0, 2}, {1, 3, 0, 0}, {0, 3, 0, 1}};
 
 const auto pad4DConstparams = testing::Combine(                //
     testing::ValuesIn(padsBegin4D),                            //

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2532,7 +2532,7 @@ Value pool(const Value& value) {
   //    1. Pool Mode (avg/max)
   //    2. Pool Size
   //    3. Strides
-  //    4. Autopad Mode (explicit, same_lower, same_upper, valid, [maybe full?])
+  //    4. Autoexplicit_padding Mode (explicit, same_lower, same_upper, valid, [maybe full?])
   //    5. Manual Padding
   //    6. Layout (i.e. Channel Order) (minimally NXC v NCX)
   //    7. Include Padding in Avg Computation (bool)

--- a/plaidml/op/lib/ops.cc
+++ b/plaidml/op/lib/ops.cc
@@ -2487,7 +2487,7 @@ Value l2norm(const Value& value) {
       X = X + epsilon;
       break;
     case EpsMode::MAX:
-      X = op::maximum(X, edsl::Tensor{epsilon});
+      X = op::maximum(X, edsl::cast(edsl::Tensor{epsilon}, X.dtype()));
       break;
     default:
       throw std::runtime_error("Unrecognized eps_mode in l2norm op");


### PR DESCRIPTION
Add openvino bridge tests for `broadcast`,  `fake_quantize`,  `normalize_l2`, `pad`.

Commented cases that fail from 
* FP16 is not supported
* Some modes are not implemented