### PR TITLE
Fix detectionoutput

### DIFF
--- a/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/detection_output.cpp
+++ b/plaidml/bridge/openvino/tests/functional/shared_tests_instances/single_layer_tests/detection_output.cpp
@@ -107,8 +107,8 @@ const auto params5Inputs = ::testing::Combine(  //
     ::testing::Values(objectnessScore),         //
     ::testing::Values(CommonTestUtils::DEVICE_PLAIDML));
 
-// INSTANTIATE_TEST_CASE_P(DetectionOutput5In, DetectionOutputLayerTest, params5Inputs,
-//                        DetectionOutputLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(DetectionOutput5In, DetectionOutputLayerTest, params5Inputs,
+                        DetectionOutputLayerTest::getTestCaseName);
 
 const std::vector<ParamsWhichSizeDepends> smokeParams5In = {
     ParamsWhichSizeDepends{true, true, true, 1, 1, {1, 60}, {1, 165}, {1, 1, 60}, {1, 30}, {1, 60}},


### PR DESCRIPTION
The DetectionOutput5In has already been fixed by [Openvino](https://github.com/Flex-plaidml-team/openvino/commit/cdc98d72868cb938c716b873b6ad9e495d764cb9#diff-751ce0e02e3417d7e240718c953895842fc03ec43d373c580beabe607281e32b) So I enable the DetectionOutput5In.